### PR TITLE
[FEATURE] - Custom State Backend

### DIFF
--- a/charts/terranetes-controller/templates/deployment.yaml
+++ b/charts/terranetes-controller/templates/deployment.yaml
@@ -56,6 +56,9 @@ spec:
             {{- if .Values.controller.costs.secret }}
             - --cost-secret={{ .Values.controller.costs.secret }}
             {{- end }}
+            {{- if .Values.controller.backendTemplate }}
+            - --backend-template={{ .Values.controller.backendTemplate }}
+            {{- end }}
             - --drift-controller-interval={{ .Values.controller.driftControllerInterval }}
             - --drift-interval={{ .Values.controller.driftInterval }}
             - --drift-threshold={{ .Values.controller.driftThreshold }}

--- a/charts/terranetes-controller/values.yaml
+++ b/charts/terranetes-controller/values.yaml
@@ -19,6 +19,10 @@ controller:
   # Executor secrets includes the following secrets in 'all' execution jobs. The secret is added
   # as an environment variables (spec.envFrom) into the terranetes container of the executor
   executorSecrets: []
+  # Overrides the default terraform state backend from Kubernetes secret to anything defined on the
+  # template. This value is the name of a secret in the controller namespace which contains a
+  # backend.tf key, holding a golang template to use for the terraform state
+  backendTemplate: ""
   # Configuration related to costs
   costs:
     # Name of the secret containing the infracost api token

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -53,6 +53,7 @@ func main() {
 
 	flags := cmd.Flags()
 	flags.Bool("verbose", false, "Enable verbose logging")
+	flags.StringVar(&config.BackendTemplate, "backend-template", "", "Name of secret in the controller namespace containing a template for the terraform state")
 	flags.BoolVar(&config.EnableTerraformVersions, "enable-terraform-versions", true, "Indicates the terraform version can be overridden by configurations")
 	flags.BoolVar(&config.EnableWatchers, "enable-watchers", true, "Indicates we create watcher jobs in the configuration namespaces")
 	flags.BoolVar(&config.EnableWebhook, "enable-webhook", true, "Indicates we should register the webhooks")

--- a/pkg/controller/configuration/controller.go
+++ b/pkg/controller/configuration/controller.go
@@ -60,20 +60,23 @@ type Controller struct {
 	cache *cache.Cache
 	// recorder is the kubernetes event recorder
 	recorder record.EventRecorder
-	// ExecutorSecrets is a collection of secrets which should be added to the
-	// executors job everytime - these are configured by the platform team on the
-	// cli options
-	ExecutorSecrets []string
 	// ControllerNamespace is the namespace where the runner is running
 	ControllerNamespace string
+	// BackendTemplate is the name of the secret in the controller namespace which holds a
+	// template used to generate the state backend
+	BackendTemplate string
 	// EnableInfracosts enables the cost analytics via infracost
 	EnableInfracosts bool
+	// EnableTerraformVersions enables the use of the configuration's Terraform version
+	EnableTerraformVersions bool
 	// EnableWatchers indicates we should create watcher jobs in the user namespace
 	EnableWatchers bool
 	// ExecutorImage is the image to use for the executor
 	ExecutorImage string
-	// EnableTerraformVersions enables the use of the configuration's Terraform version
-	EnableTerraformVersions bool
+	// ExecutorSecrets is a collection of secrets which should be added to the
+	// executors job everytime - these are configured by the platform team on the
+	// cli options
+	ExecutorSecrets []string
 	// InfracostsImage is the image to use for all infracost jobs
 	InfracostsImage string
 	// InfracostsSecretName is the name of the secret containing the api and token
@@ -86,10 +89,16 @@ type Controller struct {
 	TerraformImage string
 }
 
+// HasBackendTemplate returns true if the configuration has a backend template
+func (c *Controller) HasBackendTemplate() bool {
+	return c.BackendTemplate != ""
+}
+
 // Add is called to setup the manager for the controller
 func (c *Controller) Add(mgr manager.Manager) error {
 	log.WithFields(log.Fields{
 		"additional_secrets": len(c.ExecutorSecrets),
+		"backend":            c.BackendTemplate,
 		"enable_costs":       c.EnableInfracosts,
 		"enable_watchers":    c.EnableWatchers,
 		"namespace":          c.ControllerNamespace,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -143,6 +143,7 @@ func New(cfg *rest.Config, config Config) (*Server, error) {
 
 	if err := (&configuration.Controller{
 		ControllerNamespace:     config.Namespace,
+		BackendTemplate:         config.BackendTemplate,
 		EnableInfracosts:        (config.InfracostsSecretName != ""),
 		EnableTerraformVersions: config.EnableTerraformVersions,
 		EnableWatchers:          config.EnableWatchers,

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -21,14 +21,19 @@ import "time"
 
 // Config is the configuration for the controller
 type Config struct {
-	// ExecutorSecrets is a list of additional secrets to be added to the executor
-	ExecutorSecrets []string
 	// APIServerPort is the port to listen on
 	APIServerPort int
+	// BackendTemplate is the name of a secret in the controller namespace which
+	// contains an optional template to use for the backend state - unless this
+	// is set we use the default backend state i.e. kubernetes state
+	BackendTemplate string
 	// DriftControllerInterval is the interval for the controller to check for drift
 	DriftControllerInterval time.Duration
 	// DriftInterval is the minimum interval between drift checks
 	DriftInterval time.Duration
+	// DriftThreshold is the max number of drifts we are running to run - this prevents the
+	// controller from running many configurations at the same time
+	DriftThreshold float64
 	// EnableWebhook enables the webhook registration
 	EnableWebhook bool
 	// EnableWatchers enables the creation of watcher jobs
@@ -37,15 +42,14 @@ type Config struct {
 	EnableTerraformVersions bool
 	// ExecutorImage is the image to use for the executor
 	ExecutorImage string
+	// ExecutorSecrets is a list of additional secrets to be added to the executor
+	ExecutorSecrets []string
 	// InfracostsSecretName is the name of the secret that contains the cost token and endpoint
 	InfracostsSecretName string
 	// InfracostsImage is the image to use for infracosts
 	InfracostsImage string
 	// JobTemplate is the name of the configmap containing a template for the jobs
 	JobTemplate string
-	// DriftThreshold is the max number of drifts we are running to run - this prevents the
-	// controller from running many configurations at the same time
-	DriftThreshold float64
 	// MetricsPort is the port to listen on
 	MetricsPort int
 	// Namespace is namespace the controller is running

--- a/pkg/utils/jobs/jobs.go
+++ b/pkg/utils/jobs/jobs.go
@@ -60,6 +60,8 @@ type Options struct {
 	PolicyConstraint *terraformv1alphav1.PolicyConstraint
 	// PolicyImage is image to use for checkov
 	PolicyImage string
+	// SaveTerraformState indicates we should save the terraform state in a secret
+	SaveTerraformState bool
 	// Template is the source for the job template if overridden by the controller
 	Template []byte
 	// TerraformImage is the image to use for the terraform jobs
@@ -198,6 +200,7 @@ func (r *Render) createTerraformFromTemplate(options Options, stage string) (*ba
 		"ExecutorSecrets":        options.ExecutorSecrets,
 		"ImagePullPolicy":        "IfNotPresent",
 		"Policy":                 options.PolicyConstraint,
+		"SaveTerraformState":     options.SaveTerraformState,
 		"ServiceAccount":         DefaultServiceAccount,
 		"Stage":                  stage,
 		"TerraformArguments":     arguments,
@@ -221,6 +224,7 @@ func (r *Render) createTerraformFromTemplate(options Options, stage string) (*ba
 			"Infracosts":       options.InfracostsSecret,
 			"InfracostsReport": r.configuration.GetTerraformCostSecretName(),
 			"PolicyReport":     r.configuration.GetTerraformPolicySecretName(),
+			"TerraformState":   r.configuration.GetTerraformStateSecretName(),
 		},
 	}
 

--- a/test/fixtures/state.go
+++ b/test/fixtures/state.go
@@ -57,6 +57,30 @@ var fakeCostsReport = `
 }
 `
 
+var fakeBackendTemplate = `
+terraform {
+  backend "s3" {
+    bucket     = "terranetes-controller-state"
+    key        = "cluster_one/{{ .namespace }}/{{ .name }}"
+    region     = "eu-west-2"
+    access_key = "AWS_ACCESS_KEY_ID"
+    secret_key = "AWS_SECRET_ACCESS_KEY"
+  }
+}
+`
+
+// NewBackendTemplateSecret returns a fake backend template secret
+func NewBackendTemplateSecret(namespace, name string) *v1.Secret {
+	secret := &v1.Secret{}
+	secret.Name = name
+	secret.Namespace = namespace
+	secret.Data = map[string][]byte{
+		"backend.tf": []byte(fakeBackendTemplate),
+	}
+
+	return secret
+}
+
 // NewCostsSecret returns a fake costs secret
 func NewCostsSecret(namespace, name string) *v1.Secret {
 	secret := &v1.Secret{}


### PR DESCRIPTION
Currently we only support kubernetes as a backend for the terraform state of the Configuration. This this PR
we've introduced the ability to define a custom template and support any backend supported by Terraform.

- updated the helm chart to support backendTemplate
- added a new --backend-template to the controller
- added the unit tests and checks (missing e2e for now)
- updated the job template to upload the terraform state

You can upload a kubernetes secret such as 

```yaml 
terraform {
  backend "s3" {
    bucket     = "terranetes-controller-state"
    key        = "cluster_one/{{ .namespace }}/{{ .name }}
    region     = "eu-west-2"
    access_key = "AWS_ACCESS_KEY_ID"
    secret_key = "AWS_SECRET_ACCESS_KEY"
  }
}
```

```bash 
# Note the key has to be backend.tf
kubectl -n terraform-system create secret generic backend --from-file=backend.tf=PATH
```

And then update the controller flag `--backend-template` or helm values

```yaml
controller:
   backendTemplate: backend # i.e. the name of the secret 
```