### PR TITLE
[BUGFIX] - CLI Configuration

### DIFF
--- a/pkg/cmd/factory.go
+++ b/pkg/cmd/factory.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	k8sclient "k8s.io/client-go/kubernetes"
@@ -81,6 +82,11 @@ func NewFactoryWithClient(cc client.Client, streams genericclioptions.IOStreams)
 func (f *factory) SaveConfig(config Config) error {
 	encoded, err := yaml.Marshal(&config)
 	if err != nil {
+		return err
+	}
+
+	// @step: ensure the directory exists
+	if err := os.MkdirAll(filepath.Dir(ConfigPath()), 0755); err != nil {
 		return err
 	}
 

--- a/pkg/cmd/factory.go
+++ b/pkg/cmd/factory.go
@@ -86,11 +86,11 @@ func (f *factory) SaveConfig(config Config) error {
 	}
 
 	// @step: ensure the directory exists
-	if err := os.MkdirAll(filepath.Dir(ConfigPath()), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(ConfigPath()), 0750); err != nil {
 		return err
 	}
 
-	return os.WriteFile(ConfigPath(), encoded, 0644)
+	return os.WriteFile(ConfigPath(), encoded, 0640)
 }
 
 // GetConfig returns true if we have a cli configuration file

--- a/pkg/cmd/tnctl/search/search.go
+++ b/pkg/cmd/tnctl/search/search.go
@@ -20,6 +20,7 @@ package search
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -124,6 +125,10 @@ func (o *Command) Run(ctx context.Context) error {
 	}
 	if !found || len(config.Sources) == 0 {
 		config.Sources = []string{"https://registry.terraform.io"}
+	}
+
+	if o.Source != "" && !utils.Contains(o.Source, config.Sources) {
+		return fmt.Errorf("source %q not found in configuration", o.Source)
 	}
 
 	// @step: ensure we have something to search for


### PR DESCRIPTION
On saving the configuration file we were not checking the directory structure existed. Also when passing a --source option to the search we were checking the source was available in the configuration
