### PR TITLE
[FEATURE] - Using Repository Name in Search

### DIFF
--- a/pkg/cmd/search/github/github.go
+++ b/pkg/cmd/search/github/github.go
@@ -246,6 +246,8 @@ func (r *ghClient) searchByOrganization(ctx context.Context, _ search.Query) ([]
 func containsTerms(query string, repostory *githubcc.Repository) bool {
 	terms := strings.ToLower(strings.ReplaceAll(repostory.GetDescription(), ",", " "))
 	terms = terms + " " + strings.ToLower(strings.Join(repostory.Topics, " "))
+	terms = terms + " " + strings.ToLower(strings.ReplaceAll(repostory.GetName(), "-", " "))
+
 	lower := strings.ToLower(query)
 
 	return utils.ContainsList(strings.Split(lower, " "), strings.Split(terms, " "))


### PR DESCRIPTION
At present we only take into account the description and the topics when searching for terms. With this PR we also using the name of the repository as well
