### PR TITLE
[HELM] - Bugfix Helm Template (Policies & Providers)

### DIFF
--- a/charts/terranetes-controller/Chart.yaml
+++ b/charts/terranetes-controller/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: terranetes-controller
 description: Controller used to provision a terraform workflow within kubernetes
 type: application
-version: v0.3.3
+version: v0.3.4
 appVersion: v0.3.2
 sources:
   - https://github.com/appvia/terranetes-controller

--- a/charts/terranetes-controller/templates/policies.yaml
+++ b/charts/terranetes-controller/templates/policies.yaml
@@ -16,4 +16,4 @@ metadata:
     {{- end }}
 spec:
   constraints: {{ $constraint | toYaml | nindent 4 }}
-{{- end }}
+{{ end }}

--- a/charts/terranetes-controller/templates/providers.yaml
+++ b/charts/terranetes-controller/templates/providers.yaml
@@ -30,4 +30,4 @@ spec:
   {{- if eq $provider.source "injected" }}
   serviceAccount: {{ $provider.serviceAccount }}
   {{- end }}
-{{- end }}
+{{ end }}


### PR DESCRIPTION
There is a bug in the template for the policies and providers which is causing the seperator to be place into the wrong place

When running `helm upgrade --install -n terraform-system terranetes charts/terranetes-controller/ --create-namespace --values dev/my_values.yaml --dry-run`

I was getting the following

```YAML
# Source: terranetes-controller/templates/providers.yaml
apiVersion: terraform.appvia.io/v1alpha1
kind: Provider
metadata:
  name: aws
  annotations:
  labels:
spec:
  source: injected
  provider: aws
  serviceAccount: terraform-executor---
apiVersion: terraform.appvia.io/v1alpha1
kind: Provider
metadata:
  name: azure
  annotations:
  labels:
spec:
  source: injected
  provider: azure
  serviceAccount: terraform-executor
```

Post the change we go to 

```YAML
---
# Source: terranetes-controller/templates/providers.yaml
apiVersion: terraform.appvia.io/v1alpha1
kind: Provider
metadata:
  name: aws
  annotations:
  labels:
spec:
  source: injected
  provider: aws
  serviceAccount: terraform-executor
---
# Source: terranetes-controller/templates/providers.yaml
apiVersion: terraform.appvia.io/v1alpha1
kind: Provider
metadata:
  name: azure
  annotations:
  labels:
spec:
  source: injected
  provider: azure
  serviceAccount: terraform-executor
```

As expected