### PR TITLE
[FEATURE] - Removing Kubectl from Executor Image

### DIFF
--- a/cmd/step/types.go
+++ b/cmd/step/types.go
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2022  Appvia Ltd <info@appvia.io>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Step represents a stage to run
+type Step struct {
+	// Commands is the commands and arguments to run
+	Commands []string
+	// Comment adds a banner to the stage
+	Comment string
+	// ErrorFile is the path to a file which is created when the command failed
+	ErrorFile string
+	// FailureFile is the path to a file indicating failure
+	FailureFile string
+	// Namespace is the namespace to upload any files to as a secret
+	Namespace string
+	// Shell is the shell to execute the command in
+	Shell string
+	// SuccessFile is the path to a file which is created when the command ran successfully
+	SuccessFile string
+	// Timeout is the max time to wait on file before considering the run a failure
+	Timeout time.Duration
+	// UploadFile is file to upload on success of the command
+	UploadFile []string
+	// WaitFile is the path to a file which is wait for to run
+	WaitFile string
+}
+
+// IsValid returns an error if the skip configuation is invalid
+func (s Step) IsValid() error {
+	switch {
+	case len(s.Commands) == 0:
+		return errors.New("no commands specified")
+
+	case s.Timeout < 0:
+		return errors.New("timeout must be greater than 0")
+
+	case len(s.UploadFile) > 0 && s.Namespace == "":
+		return errors.New("namespace must be specified when uploading files")
+
+	case len(s.UploadFile) > 0:
+		for _, x := range s.UploadFile {
+			if e := strings.Split(x, "="); len(e) != 2 {
+				return fmt.Errorf("upload file must be in the format 'key=path'")
+			}
+		}
+	}
+
+	return nil
+}
+
+// UploadKeyPairs returns a map of key pairs to upload
+func (s Step) UploadKeyPairs() map[string]string {
+	if len(s.UploadFile) == 0 {
+		return nil
+	}
+
+	keys := make(map[string]string)
+	for _, x := range s.UploadFile {
+		if e := strings.Split(x, "="); len(e) == 2 {
+			keys[e[0]] = e[1]
+		}
+	}
+
+	return keys
+}

--- a/images/Dockerfile.executor
+++ b/images/Dockerfile.executor
@@ -3,20 +3,10 @@ FROM golang:1.18 AS builder
 ARG VERSION=latest
 ARG LFLAGS
 
-ENV \
-  KUBECTL_VERSION="1.23.0"
-
-ENV \
-  KUBECTL_BINARY_URL=https://dl.k8s.io/release/v${KUBECTL_VERSION}/bin/linux/amd64/kubectl
-
-RUN curl -sL -o /usr/bin/kubectl ${KUBECTL_BINARY_URL} && chmod +x /usr/bin/kubectl
-
 COPY . /go/src/github.com/appvia/terranetes-controller
 
 ENV CGO_ENABLED=0
 ENV VERSION=$VERSION
-
-RUN /usr/bin/kubectl version --client
 
 RUN cd /go/src/github.com/appvia/terranetes-controller && make source
 RUN cd /go/src/github.com/appvia/terranetes-controller && make step
@@ -27,7 +17,6 @@ RUN apk add ca-certificates curl unzip
 
 RUN apk add ca-certificates bash openssh git
 
-COPY --from=builder /usr/bin/kubectl /bin/kubectl
 COPY --from=builder /go/src/github.com/appvia/terranetes-controller/bin/source /bin/source
 COPY --from=builder /go/src/github.com/appvia/terranetes-controller/bin/step /bin/step
 

--- a/pkg/controller/configuration/reconcile_test.go
+++ b/pkg/controller/configuration/reconcile_test.go
@@ -68,8 +68,8 @@ var _ = Describe("Configuration Controller", func() {
 		"--comment=Evaluating Against Security Policy",
 		"--command=/usr/local/bin/checkov --config /run/checkov/checkov.yaml -f /run/plan.json -o json -o cli --output-file-path /run >/dev/null",
 		"--command=/bin/cat /run/results_cli.txt",
-		"--command=/run/bin/kubectl -n $(KUBE_NAMESPACE) delete secret $(POLICY_REPORT_NAME) --ignore-not-found >/dev/null",
-		"--command=/run/bin/kubectl -n $(KUBE_NAMESPACE) create secret generic $(POLICY_REPORT_NAME) --from-file=/run/results_json.json >/dev/null",
+		"--namespace=$(KUBE_NAMESPACE)",
+		"--upload=$(POLICY_REPORT_NAME)=/run/results_json.json",
 		"--is-failure=/run/steps/terraform.failed",
 		"--wait-on=/run/steps/terraform.complete",
 	}
@@ -1595,8 +1595,8 @@ terraform {
 					"--comment=Evaluating Against Security Policy",
 					"--command=/usr/local/bin/checkov --config /run/checkov/checkov.yaml -f /run/plan.json -o json -o cli --output-file-path /run >/dev/null",
 					"--command=/bin/cat /run/results_cli.txt",
-					"--command=/run/bin/kubectl -n $(KUBE_NAMESPACE) delete secret $(POLICY_REPORT_NAME) --ignore-not-found >/dev/null",
-					"--command=/run/bin/kubectl -n $(KUBE_NAMESPACE) create secret generic $(POLICY_REPORT_NAME) --from-file=/run/results_json.json >/dev/null",
+					"--namespace=$(KUBE_NAMESPACE)",
+					"--upload=$(POLICY_REPORT_NAME)=/run/results_json.json",
 					"--is-failure=/run/steps/terraform.failed",
 					"--wait-on=/run/steps/terraform.complete",
 				}))


### PR DESCRIPTION
Currently we use kubectl in the executor to upload any assets required into kubernetes secrets - i.e. the cost report, terraform state and so forth. In this pull request added a new --upload command line which performs this requirement for us in the step command. On success completion any files will be uploaded.
