### PR TITLE
[CLEAN] - Dependencies Shuffle

### DIFF
--- a/pkg/cmd/factory_test.go
+++ b/pkg/cmd/factory_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func TestNewFactory(t *testing.T) {
@@ -65,17 +64,4 @@ func TestPrintf(t *testing.T) {
 
 	factory.Printf("Hello %s", "World")
 	assert.Equal(t, "Hello World", b.String())
-}
-
-func TestGetClient(t *testing.T) {
-	factory, err := NewFactory(
-		WithClient(fake.NewClientBuilder().Build()),
-		WithStreams(genericclioptions.IOStreams{}),
-	)
-	assert.NoError(t, err)
-	assert.NotNil(t, factory)
-
-	cc, err := factory.GetClient()
-	assert.NoError(t, err)
-	assert.NotNil(t, cc)
 }

--- a/pkg/controller/configuration/ensure.go
+++ b/pkg/controller/configuration/ensure.go
@@ -353,7 +353,7 @@ func (c *Controller) ensureProviderReady(configuration *terraformv1alphav1.Confi
 			namespace := value.(*v1.Namespace)
 
 			// @step: ensure we have match the selector of the provider - i.e our namespace and resource labels must match
-			match, err := utils.IsSelectorMatch(*provider.Spec.Selector, configuration.GetLabels(), namespace.GetLabels())
+			match, err := kubernetes.IsSelectorMatch(*provider.Spec.Selector, configuration.GetLabels(), namespace.GetLabels())
 			if err != nil {
 				cond.Failed(err, "Failed to check against the provider policy")
 

--- a/pkg/handlers/configurations/validation.go
+++ b/pkg/handlers/configurations/validation.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	terraformv1alphav1 "github.com/appvia/terranetes-controller/pkg/apis/terraform/v1alpha1"
-	"github.com/appvia/terranetes-controller/pkg/utils"
 	"github.com/appvia/terranetes-controller/pkg/utils/kubernetes"
 )
 
@@ -168,7 +167,7 @@ func validateProvider(ctx context.Context, cc client.Client, configuration *terr
 		return nil
 	}
 
-	matched, err := utils.IsSelectorMatch(*provider.Spec.Selector, configuration.GetLabels(), namespace.GetLabels())
+	matched, err := kubernetes.IsSelectorMatch(*provider.Spec.Selector, configuration.GetLabels(), namespace.GetLabels())
 	if err != nil {
 		return err
 	}
@@ -194,7 +193,7 @@ func validateModuleConstriants(
 			continue
 		}
 		if x.Spec.Constraints.Modules.Selector != nil {
-			matched, err := utils.IsSelectorMatch(*x.Spec.Constraints.Modules.Selector, configuration.GetLabels(), namespace.GetLabels())
+			matched, err := kubernetes.IsSelectorMatch(*x.Spec.Constraints.Modules.Selector, configuration.GetLabels(), namespace.GetLabels())
 			if err != nil {
 				return err
 			} else if !matched {

--- a/pkg/utils/kubernetes/labels.go
+++ b/pkg/utils/kubernetes/labels.go
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package utils
+package kubernetes
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/utils/kubernetes/labels_test.go
+++ b/pkg/utils/kubernetes/labels_test.go
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package utils
+package kubernetes
 
 import (
 	"testing"

--- a/pkg/utils/kubernetes/time.go
+++ b/pkg/utils/kubernetes/time.go
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package utils
+package kubernetes
 
 import (
 	"time"

--- a/pkg/utils/kubernetes/time_test.go
+++ b/pkg/utils/kubernetes/time_test.go
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package utils
+package kubernetes
 
 import (
 	"testing"


### PR DESCRIPTION
This pull request is purely to move methods around to isolate the dependenicies a little better.

- moved anything related to kubernetes into pkg/utils/kubernetes package
- removed the unrequired factory method NewFactoryWithClient as it can be done with options