### PR TITLE
[FEATURE] - Configuration Status Metrics

### DIFF
--- a/pkg/apis/core/v1alpha1/status_types.go
+++ b/pkg/apis/core/v1alpha1/status_types.go
@@ -124,6 +124,20 @@ func (s *CommonStatus) GetCommonStatus() *CommonStatus {
 	return s
 }
 
+// IsFailed returns true if the status of any of the conditions is in error
+func (s *CommonStatus) IsFailed() bool {
+	for _, c := range s.Conditions {
+		if c.Status == metav1.ConditionFalse {
+			switch c.Reason {
+			case ReasonError, ReasonErrorDeleting, ReasonWarning, ReasonActionRequired:
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 // CommonStatusAware is implemented by any Wayfinder resource which has the standard Wayfinder common status
 // implementation
 // +kubebuilder:object:generate=false

--- a/pkg/controller/configuration/metrics.go
+++ b/pkg/controller/configuration/metrics.go
@@ -30,6 +30,12 @@ func init() {
 }
 
 var (
+	statusMetric = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "configuration_status",
+			Help: "Indicates the status of the configuration, 0 = OK, 1 = Error",
+		}, []string{"name", "namespace"},
+	)
 	hourlyCostMetric = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "configuration_hourly_cost_total",

--- a/pkg/controller/configuration/reconcile.go
+++ b/pkg/controller/configuration/reconcile.go
@@ -68,6 +68,18 @@ func (c *Controller) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
+	defer func() {
+		var status float64
+		if configuration.Status.GetCommonStatus().IsFailed() {
+			status = 1
+		}
+
+		statusMetric.WithLabelValues(
+			configuration.Name,
+			configuration.Namespace,
+		).Set(status)
+	}()
+
 	state := &state{valueFrom: make(map[string]string), backendTemplate: terraform.KubernetesBackendTemplate}
 
 	finalizer := controller.NewFinalizer(c.cc, controllerName)


### PR DESCRIPTION
Currently we do not have a prometheus metrics for the status of the configuration. This this change we've introduced a configuration_status can which can be used to track and trigger on Configuration which have errors
