### PR TITLE
[FEATURE] - Context Injection

### DIFF
--- a/charts/terranetes-controller/templates/deployment.yaml
+++ b/charts/terranetes-controller/templates/deployment.yaml
@@ -62,6 +62,7 @@ spec:
             - --drift-controller-interval={{ .Values.controller.driftControllerInterval }}
             - --drift-interval={{ .Values.controller.driftInterval }}
             - --drift-threshold={{ .Values.controller.driftThreshold }}
+            - --enable-context-injection={{ .Values.controller.enableContextInjection }}
             - --enable-terraform-versions={{ .Values.controller.enableTerraformVersions }}
             - --enable-watchers={{ .Values.controller.enableWatchers }}
             - --enable-webhook={{ .Values.controller.webhooks.enabled }}

--- a/charts/terranetes-controller/values.yaml
+++ b/charts/terranetes-controller/values.yaml
@@ -65,7 +65,15 @@ controller:
   # enableTerraformVersions indicates configurations are permitted to override
   # the terraform version in their spec.
   enableTerraformVersions: true
-
+  # enableContextInjection indicates the controller should add the terranetes
+  # map variable into all configurations. This adds a varaible called 'terraform'
+  # terranetes:
+  #   namespace: ""
+  #   name: ""
+  #   labels {}
+  # into the terraform variables of every module. Note, this doesn't mean you have
+  # to use it, but if you do the variables are there.
+  enableContextInjection: false
   # The default terraform version (or tag of the above image)
   webhooks:
     # enables the webhooks

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -54,6 +54,7 @@ func main() {
 	flags := cmd.Flags()
 	flags.Bool("verbose", false, "Enable verbose logging")
 	flags.StringVar(&config.BackendTemplate, "backend-template", "", "Name of secret in the controller namespace containing a template for the terraform state")
+	flags.BoolVar(&config.EnableContextInjection, "enable-context-injection", false, "Indicates the controller should inject Configuration context into the terraform variables")
 	flags.BoolVar(&config.EnableTerraformVersions, "enable-terraform-versions", true, "Indicates the terraform version can be overridden by configurations")
 	flags.BoolVar(&config.EnableWatchers, "enable-watchers", true, "Indicates we create watcher jobs in the configuration namespaces")
 	flags.BoolVar(&config.EnableWebhook, "enable-webhook", true, "Indicates we should register the webhooks")

--- a/pkg/controller/configuration/controller.go
+++ b/pkg/controller/configuration/controller.go
@@ -65,6 +65,10 @@ type Controller struct {
 	// BackendTemplate is the name of the secret in the controller namespace which holds a
 	// template used to generate the state backend
 	BackendTemplate string
+	// EnableContextInjection enables the injection of the context into the terraform configuration
+	// variables. This means we shall inject an number of default variables into the configuration
+	// such as namespace, name and labels
+	EnableContextInjection bool
 	// EnableInfracosts enables the cost analytics via infracost
 	EnableInfracosts bool
 	// EnableTerraformVersions enables the use of the configuration's Terraform version

--- a/pkg/controller/configuration/ensure.go
+++ b/pkg/controller/configuration/ensure.go
@@ -430,6 +430,14 @@ func (c *Controller) ensureJobConfigurationSecret(configuration *terraformv1alph
 			variables[key] = value
 		}
 
+		// @step: should we inject the context?
+		if c.EnableContextInjection {
+			variables["terranetes"] = map[string]interface{}{
+				"name":      configuration.Name,
+				"namespace": configuration.Namespace,
+			}
+		}
+
 		// @step: if the any variables for this job lets add them
 		switch len(variables) == 0 {
 		case true:

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -34,6 +34,10 @@ type Config struct {
 	// DriftThreshold is the max number of drifts we are running to run - this prevents the
 	// controller from running many configurations at the same time
 	DriftThreshold float64
+	// EnableContextInjection indicates the controller should always inject the context
+	// into the terraform variables - i.e. namespace and name under a terraform variable
+	// called 'terranetes'
+	EnableContextInjection bool
 	// EnableWebhook enables the webhook registration
 	EnableWebhook bool
 	// EnableWatchers enables the creation of watcher jobs

--- a/test/e2e/integration/infracost.bats
+++ b/test/e2e/integration/infracost.bats
@@ -64,6 +64,6 @@ teardown() {
 }
 
 @test "We should be able to destroy the aws configuration for costs" {
-  runit "kubectl -n ${APP_NAMESPACE} delete -f ${BATS_TMPDIR}/resource.yml --wait=false"
+  runit "kubectl -n ${APP_NAMESPACE} delete -f ${BATS_TMPDIR}/resource.yml"
   [[ "$status" -eq 0 ]]
 }


### PR DESCRIPTION
Currently terraform modules used by the controller has no means of gather context from the Configuration itself - i.e. namespace, name, labels and so forth. It can be useful to have these detail however, so instance prefixing configuration with namespace name or adding tags. In the change we've introduce an --enable-context-injection which optional turns on the feature and injects a map into the terraform module terranetes.{} with name and namespace attributes
