### PR TITLE
[IMAGES] - Bumping Infracost to v0.10.9

### DIFF
--- a/charts/terranetes-controller/values.yaml
+++ b/charts/terranetes-controller/values.yaml
@@ -33,7 +33,7 @@ controller:
     # is the default image to use for terraform operations
     terraform: hashicorp/terraform:1.2.5
     # image to use for infracost
-    infracost: infracost/infracost:0.10.8
+    infracost: infracost/infracost:0.10.9
     # policy is image for policy
     policy: bridgecrew/checkov:2.1.67
     # is the controller image


### PR DESCRIPTION
Bumping the default image of infracost to v0.10.9 from v0.10.8
