### PR TITLE
[BUILD] - Upgrading Base Image (Alpine 3.15 -> 3.16)

### DIFF
--- a/images/Dockerfile.controller
+++ b/images/Dockerfile.controller
@@ -11,7 +11,7 @@ ENV \
 
 RUN cd /go/src/github.com/appvia/terranetes-controller && make controller
 
-FROM alpine:3.15.4
+FROM alpine:3.16
 
 RUN apk add ca-certificates
 

--- a/images/Dockerfile.executor
+++ b/images/Dockerfile.executor
@@ -11,7 +11,7 @@ ENV VERSION=$VERSION
 RUN cd /go/src/github.com/appvia/terranetes-controller && make source
 RUN cd /go/src/github.com/appvia/terranetes-controller && make step
 
-FROM alpine:3.15.4
+FROM alpine:3.16
 
 RUN apk add ca-certificates curl unzip
 


### PR DESCRIPTION
Upgrading the base image of the controller and executor to alpine 3.16
