### PR TITLE
[E2E] - Bug Fixes in E2E

### DIFF
--- a/test/e2e/integration/cloud/aws/plan.bats
+++ b/test/e2e/integration/cloud/aws/plan.bats
@@ -33,7 +33,7 @@ kind: Configuration
 metadata:
   name: ${RESOURCE_NAME}
 spec:
-  module: https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git?ref=v3.1.0
+  module: https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git?ref=v3.3.0
   enableDriftDetection: true
   providerRef:
     name: aws


### PR DESCRIPTION
When moving to terraform 1.2.7 the current aws module we were using for the bucket was failing.
I've bumped the version of the module from 0.3.1 to 0.3.3
