### PR TITLE
[IMAGES] - Terraform Image Version Downgrade (1.2.7 -> 1.2.5)

### DIFF
--- a/charts/terranetes-controller/values.yaml
+++ b/charts/terranetes-controller/values.yaml
@@ -31,7 +31,7 @@ controller:
   # Configuration for the images used by the jobs
   images:
     # is the default image to use for terraform operations
-    terraform: hashicorp/terraform:1.2.7
+    terraform: hashicorp/terraform:1.2.5
     # image to use for infracost
     infracost: infracost/infracost:0.10.10
     # policy is image for policy


### PR DESCRIPTION
Experiencing issues with our E2E modules, not sure why they are kicked up a fuss but
dont have the time to look at the moment
