### PR TITLE
[IMAGES] - Bumping the CLI Base Image (3.15 -> 3.16)

### DIFF
--- a/images/Dockerfile.cli
+++ b/images/Dockerfile.cli
@@ -11,7 +11,7 @@ ENV \
 
 RUN cd /go/src/github.com/appvia/terranetes-controller && make tnctl
 
-FROM alpine:3.15.4
+FROM alpine:3.16
 
 RUN apk add ca-certificates
 


### PR DESCRIPTION
Bumping the base image of the CLI to Alpine 3.16
