### PR TITLE
[BUILD] - Executor Service Account to terranetes-executor

### DIFF
--- a/charts/terranetes-controller/templates/rbac.yaml
+++ b/charts/terranetes-controller/templates/rbac.yaml
@@ -171,7 +171,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: terraform-executor
+  name: terranetes-executor
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -183,7 +183,7 @@ subjects:
     apiGroup: rbac.authorization.k8s.io
   {{- else }}
   - kind: ServiceAccount
-    name: terraform-executor
+    name: terranetes-executor
     namespace: {{ .Release.Namespace }}
   {{- end }}
 {{- end }}

--- a/charts/terranetes-controller/templates/serviceaccount.yaml
+++ b/charts/terranetes-controller/templates/serviceaccount.yaml
@@ -12,7 +12,7 @@ metadata:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: terraform-executor
+  name: terranetes-executor
   annotations:
     {{ toYaml .Values.rbac.executor.annotations | indent 4 }}
 {{- end }}

--- a/charts/terranetes-controller/values.yaml
+++ b/charts/terranetes-controller/values.yaml
@@ -130,7 +130,7 @@ rbac:
     annotations: {}
   # Configuration for the terraform executor service account
   executor:
-    # indicates we should create the terraform-executor service account
+    # indicates we should create the terranetes-executor service account
     create: true
     # annotations is a collection of annotations which should be added
     annotations: {}

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -67,7 +67,7 @@ func main() {
 	flags.IntVar(&config.MetricsPort, "metrics-port", 9090, "The port the metric endpoint binds to")
 	flags.IntVar(&config.WebhookPort, "webhooks-port", 10081, "The port the webhook endpoint binds to")
 	flags.StringSliceVar(&config.ExecutorSecrets, "executor-secret", []string{}, "Name of a secret in controller namespace which should be added to the job")
-	flags.StringVar(&config.ExecutorImage, "executor-image", "ghcr.io/appvia/terraform-executor:latest", "The image to use for the executor")
+	flags.StringVar(&config.ExecutorImage, "executor-image", "ghcr.io/appvia/terranetes-executor:latest", "The image to use for the executor")
 	flags.StringVar(&config.InfracostsImage, "infracost-image", "infracosts/infracost:latest", "The image to use for the infracosts")
 	flags.StringVar(&config.InfracostsSecretName, "cost-secret", "", "Name of the secret on the controller namespace containing your infracost token")
 	flags.StringVar(&config.Namespace, "namespace", os.Getenv("KUBE_NAMESPACE"), "The namespace the controller is running in and where jobs will run")

--- a/docs/development.md
+++ b/docs/development.md
@@ -22,7 +22,7 @@ controller:
     # is the controller image
     controller: ghcr.io/appvia/terranetes-controller:ci
     # The terraform image used when running jobs
-    executor: ghcr.io/appvia/terraform-executor:ci
+    executor: ghcr.io/appvia/terranetes-executor:ci
 ```
 
 ```shell

--- a/examples/provider.yaml
+++ b/examples/provider.yaml
@@ -17,4 +17,4 @@ metadata:
 spec:
   source: injected
   provider: aws
-  serviceAccount: terraform-executor
+  serviceAccount: terranetes-executor

--- a/pkg/controller/configuration/reconcile_test.go
+++ b/pkg/controller/configuration/reconcile_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Configuration Controller", func() {
 			recorder:            recorder,
 			EnableInfracosts:    false,
 			EnableWatchers:      true,
-			ExecutorImage:       "ghcr.io/appvia/terraform-executor",
+			ExecutorImage:       "ghcr.io/appvia/terranetes-executor",
 			InfracostsImage:     "infracosts/infracost:latest",
 			ControllerNamespace: "default",
 			PolicyImage:         "bridgecrew/checkov:2.0.1140",
@@ -200,7 +200,7 @@ var _ = Describe("Configuration Controller", func() {
 
 				Expect(cc.List(context.TODO(), list, client.InNamespace(ctrl.ControllerNamespace))).ToNot(HaveOccurred())
 				Expect(len(list.Items)).To(Equal(1))
-				Expect(list.Items[0].Spec.Template.Spec.ServiceAccountName).To(Equal("terraform-executor"))
+				Expect(list.Items[0].Spec.Template.Spec.ServiceAccountName).To(Equal("terranetes-executor"))
 			})
 		})
 

--- a/pkg/utils/jobs/jobs.go
+++ b/pkg/utils/jobs/jobs.go
@@ -35,7 +35,7 @@ import (
 )
 
 // DefaultServiceAccount is the default service account to use for the job if no override is given
-const DefaultServiceAccount = "terraform-executor"
+const DefaultServiceAccount = "terranetes-executor"
 
 // TerraformContainerName is the default name for the main terraform container
 const TerraformContainerName = "terraform"


### PR DESCRIPTION
Switching the name of the account to terranetes executor inline with the rest of the
service accounts
