### PR TITLE
[BUGFIX] - Configuration Deletion

### DIFF
--- a/pkg/apis/terraform/v1alpha1/configuration_types.go
+++ b/pkg/apis/terraform/v1alpha1/configuration_types.go
@@ -276,8 +276,10 @@ const (
 	ResourcesInSync ResourceStatus = "InSync"
 	// ResourcesOutOfSync is the status when the configuration is out of sync
 	ResourcesOutOfSync ResourceStatus = "OutOfSync"
-	// DestroyingResources is the status
+	// DestroyingResources is the status when the configuration is being destroyed
 	DestroyingResources ResourceStatus = "Deleting"
+	// DestroyingResourcesFailed is the status when the configuration is being destroyed and failed
+	DestroyingResourcesFailed ResourceStatus = "DeletionFailed"
 	// UnknownResourceStatus is the status when the configuration is unknown
 	UnknownResourceStatus ResourceStatus = ""
 )

--- a/pkg/controller/configuration/delete.go
+++ b/pkg/controller/configuration/delete.go
@@ -116,8 +116,10 @@ func (c *Controller) ensureTerraformDestroy(configuration *terraformv1alphav1.Co
 			return reconcile.Result{}, nil
 
 		case jobs.IsFailed(job):
-			cond.Failed(nil, "Terraform destroy is failing")
-			return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
+			cond.Failed(nil, "Terraform destroy has failed")
+			configuration.Status.ResourceStatus = terraformv1alphav1.DestroyingResourcesFailed
+
+			return reconcile.Result{}, controller.ErrIgnore
 
 		case jobs.IsActive(job):
 			cond.InProgress("Terraform destroy is running")


### PR DESCRIPTION
Currently we continue to requeue the controller even when the deletion has failed and no retries
will be attempted. This leaves the controller printing out errors messages every 30s. It would be
better to admit defeat and highlight to the user
