### PR TITLE
[BUILD] - Removing Deprecated Linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,6 @@ run:
 
 linters:
   enable:
-    - deadcode
     - depguard
     - errcheck
     - exportloopref
@@ -17,12 +16,10 @@ linters:
     - govet
     - ineffassign
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unparam
     - unused
-    - varcheck
     - wastedassign
 
 linters-settings:

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/mikefarah/yq/v3 v3.0.0-20201202084205-8846255d1c37
 	github.com/mitchellh/gox v1.0.1
 	github.com/onsi/ginkgo/v2 v2.2.0
-	github.com/onsi/gomega v1.20.2
+	github.com/onsi/gomega v1.21.1
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/prometheus/client_golang v1.13.0
 	github.com/rodaine/hclencoder v0.0.1

--- a/go.sum
+++ b/go.sum
@@ -778,8 +778,8 @@ github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
 github.com/onsi/ginkgo/v2 v2.2.0 h1:3ZNA3L1c5FYDFTTxbFeVGGD8jYvjYauHD30YgLxVsNI=
 github.com/onsi/ginkgo/v2 v2.2.0/go.mod h1:MEH45j8TBi6u9BMogfbp0stKC5cdGjumZj5Y7AG4VIk=
-github.com/onsi/gomega v1.20.2 h1:8uQq0zMgLEfa0vRrrBgaJF2gyW9Da9BmfGV+OyUzfkY=
-github.com/onsi/gomega v1.20.2/go.mod h1:iYAIXgPSaDHak0LCMA+AWBpIKBr8WZicMxnE8luStNc=
+github.com/onsi/gomega v1.21.1 h1:OB/euWYIExnPBohllTicTHmGTrMaqJ67nIu80j0/uEM=
+github.com/onsi/gomega v1.21.1/go.mod h1:iYAIXgPSaDHak0LCMA+AWBpIKBr8WZicMxnE8luStNc=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/otiai10/copy v1.2.0 h1:HvG945u96iNadPoG2/Ja2+AUJeW5YuFQMixq9yirC+k=
 github.com/otiai10/copy v1.2.0/go.mod h1:rrF5dJ5F0t/EWSYODDu4j9/vEeYHMkc8jt0zJChqQWw=

--- a/pkg/apis/terraform/v1alpha1/configuration_types.go
+++ b/pkg/apis/terraform/v1alpha1/configuration_types.go
@@ -276,8 +276,10 @@ const (
 	ResourcesInSync ResourceStatus = "InSync"
 	// ResourcesOutOfSync is the status when the configuration is out of sync
 	ResourcesOutOfSync ResourceStatus = "OutOfSync"
-	// DestroyingResources is the status
+	// DestroyingResources is the status when the configuration is being destroyed
 	DestroyingResources ResourceStatus = "Deleting"
+	// DestroyingResourcesFailed is the status when the configuration is being destroyed and failed
+	DestroyingResourcesFailed ResourceStatus = "DeletionFailed"
 	// UnknownResourceStatus is the status when the configuration is unknown
 	UnknownResourceStatus ResourceStatus = ""
 )

--- a/pkg/assets/job.yaml.tpl
+++ b/pkg/assets/job.yaml.tpl
@@ -12,6 +12,8 @@ spec:
   backoffLimit: 2
   completions: 1
   parallelism: 1
+  # retain the jobs for 6 hours
+  ttlSecondsAfterFinished: 28800
   template:
     metadata:
       labels:
@@ -30,8 +32,6 @@ spec:
         runAsUser: 65534
         runAsGroup: 65534
         fsGroup: 65534
-      # retain the jobs for 6 hours
-      ttlSecondsAfterFinished: 28800
       volumes:
         # Used to hold the terraform module source code
         - name: source

--- a/pkg/controller/configuration/delete.go
+++ b/pkg/controller/configuration/delete.go
@@ -116,8 +116,10 @@ func (c *Controller) ensureTerraformDestroy(configuration *terraformv1alphav1.Co
 			return reconcile.Result{}, nil
 
 		case jobs.IsFailed(job):
-			cond.Failed(nil, "Terraform destroy is failing")
-			return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
+			cond.Failed(nil, "Terraform destroy has failed")
+			configuration.Status.ResourceStatus = terraformv1alphav1.DestroyingResourcesFailed
+
+			return reconcile.Result{}, controller.ErrIgnore
 
 		case jobs.IsActive(job):
 			cond.InProgress("Terraform destroy is running")

--- a/vendor/github.com/onsi/gomega/CHANGELOG.md
+++ b/vendor/github.com/onsi/gomega/CHANGELOG.md
@@ -1,3 +1,26 @@
+## v1.21.1
+
+### Features
+- Eventually and Consistently that are passed a SpecContext can provide reports when an interrupt occurs [0d063c9]
+
+## 1.21.0
+
+### Features
+- Eventually and Consistently can take a context.Context [65c01bc]
+  This enables integration with Ginkgo 2.3.0's interruptible nodes and node timeouts.
+- Introduces Eventually.Within.ProbeEvery with tests and documentation (#591) [f633800]
+- New BeKeyOf matcher with documentation and unit tests (#590) [fb586b3]
+    
+## Fixes
+- Cover the entire gmeasure suite with leak detection [8c54344]
+- Fix gmeasure leak [119d4ce]
+- Ignore new Ginkgo ProgressSignal goroutine in gleak [ba548e2]
+
+## Maintenance
+
+- Fixes crashes on newer Ruby 3 installations by upgrading github-pages gem dependency (#596) [12469a0]
+
+
 ## 1.20.2
 
 ## Fixes

--- a/vendor/github.com/onsi/gomega/RELEASING.md
+++ b/vendor/github.com/onsi/gomega/RELEASING.md
@@ -1,7 +1,13 @@
 A Gomega release is a tagged sha and a GitHub release.  To cut a release:
 
 1. Ensure CHANGELOG.md is up to date.
-  - Use `git log --pretty=format:'- %s [%h]' HEAD...vX.X.X` to list all the commits since the last release
+  - Use 
+    ```bash
+    LAST_VERSION=$(git tag --sort=version:refname | tail -n1)
+    CHANGES=$(git log --pretty=format:'- %s [%h]' HEAD...$LAST_VERSION)
+    echo -e "## NEXT\n\n$CHANGES\n\n### Features\n\n## Fixes\n\n## Maintenance\n\n$(cat CHANGELOG.md)" > CHANGELOG.md
+    ```
+   to update the changelog
   - Categorize the changes into
     - Breaking Changes (requires a major version)
     - New Features (minor version)

--- a/vendor/github.com/onsi/gomega/internal/gomega.go
+++ b/vendor/github.com/onsi/gomega/internal/gomega.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"context"
 	"time"
 
 	"github.com/onsi/gomega/types"
@@ -55,9 +56,19 @@ func (g *Gomega) Eventually(actual interface{}, intervals ...interface{}) types.
 	return g.EventuallyWithOffset(0, actual, intervals...)
 }
 
-func (g *Gomega) EventuallyWithOffset(offset int, actual interface{}, intervals ...interface{}) types.AsyncAssertion {
+func (g *Gomega) EventuallyWithOffset(offset int, actual interface{}, args ...interface{}) types.AsyncAssertion {
 	timeoutInterval := g.DurationBundle.EventuallyTimeout
 	pollingInterval := g.DurationBundle.EventuallyPollingInterval
+	intervals := []interface{}{}
+	var ctx context.Context
+	for _, arg := range args {
+		switch v := arg.(type) {
+		case context.Context:
+			ctx = v
+		default:
+			intervals = append(intervals, arg)
+		}
+	}
 	if len(intervals) > 0 {
 		timeoutInterval = toDuration(intervals[0])
 	}
@@ -65,16 +76,26 @@ func (g *Gomega) EventuallyWithOffset(offset int, actual interface{}, intervals 
 		pollingInterval = toDuration(intervals[1])
 	}
 
-	return NewAsyncAssertion(AsyncAssertionTypeEventually, actual, g, timeoutInterval, pollingInterval, offset)
+	return NewAsyncAssertion(AsyncAssertionTypeEventually, actual, g, timeoutInterval, pollingInterval, ctx, offset)
 }
 
 func (g *Gomega) Consistently(actual interface{}, intervals ...interface{}) types.AsyncAssertion {
 	return g.ConsistentlyWithOffset(0, actual, intervals...)
 }
 
-func (g *Gomega) ConsistentlyWithOffset(offset int, actual interface{}, intervals ...interface{}) types.AsyncAssertion {
+func (g *Gomega) ConsistentlyWithOffset(offset int, actual interface{}, args ...interface{}) types.AsyncAssertion {
 	timeoutInterval := g.DurationBundle.ConsistentlyDuration
 	pollingInterval := g.DurationBundle.ConsistentlyPollingInterval
+	intervals := []interface{}{}
+	var ctx context.Context
+	for _, arg := range args {
+		switch v := arg.(type) {
+		case context.Context:
+			ctx = v
+		default:
+			intervals = append(intervals, arg)
+		}
+	}
 	if len(intervals) > 0 {
 		timeoutInterval = toDuration(intervals[0])
 	}
@@ -82,7 +103,7 @@ func (g *Gomega) ConsistentlyWithOffset(offset int, actual interface{}, interval
 		pollingInterval = toDuration(intervals[1])
 	}
 
-	return NewAsyncAssertion(AsyncAssertionTypeConsistently, actual, g, timeoutInterval, pollingInterval, offset)
+	return NewAsyncAssertion(AsyncAssertionTypeConsistently, actual, g, timeoutInterval, pollingInterval, ctx, offset)
 }
 
 func (g *Gomega) SetDefaultEventuallyTimeout(t time.Duration) {

--- a/vendor/github.com/onsi/gomega/matchers.go
+++ b/vendor/github.com/onsi/gomega/matchers.go
@@ -8,27 +8,27 @@ import (
 	"github.com/onsi/gomega/types"
 )
 
-//Equal uses reflect.DeepEqual to compare actual with expected.  Equal is strict about
-//types when performing comparisons.
-//It is an error for both actual and expected to be nil.  Use BeNil() instead.
+// Equal uses reflect.DeepEqual to compare actual with expected.  Equal is strict about
+// types when performing comparisons.
+// It is an error for both actual and expected to be nil.  Use BeNil() instead.
 func Equal(expected interface{}) types.GomegaMatcher {
 	return &matchers.EqualMatcher{
 		Expected: expected,
 	}
 }
 
-//BeEquivalentTo is more lax than Equal, allowing equality between different types.
-//This is done by converting actual to have the type of expected before
-//attempting equality with reflect.DeepEqual.
-//It is an error for actual and expected to be nil.  Use BeNil() instead.
+// BeEquivalentTo is more lax than Equal, allowing equality between different types.
+// This is done by converting actual to have the type of expected before
+// attempting equality with reflect.DeepEqual.
+// It is an error for actual and expected to be nil.  Use BeNil() instead.
 func BeEquivalentTo(expected interface{}) types.GomegaMatcher {
 	return &matchers.BeEquivalentToMatcher{
 		Expected: expected,
 	}
 }
 
-//BeComparableTo uses gocmp.Equal to compare. You can pass cmp.Option as options.
-//It is an error for actual and expected to be nil.  Use BeNil() instead.
+// BeComparableTo uses gocmp.Equal to compare. You can pass cmp.Option as options.
+// It is an error for actual and expected to be nil.  Use BeNil() instead.
 func BeComparableTo(expected interface{}, opts ...cmp.Option) types.GomegaMatcher {
 	return &matchers.BeComparableToMatcher{
 		Expected: expected,
@@ -36,116 +36,124 @@ func BeComparableTo(expected interface{}, opts ...cmp.Option) types.GomegaMatche
 	}
 }
 
-//BeIdenticalTo uses the == operator to compare actual with expected.
-//BeIdenticalTo is strict about types when performing comparisons.
-//It is an error for both actual and expected to be nil.  Use BeNil() instead.
+// BeIdenticalTo uses the == operator to compare actual with expected.
+// BeIdenticalTo is strict about types when performing comparisons.
+// It is an error for both actual and expected to be nil.  Use BeNil() instead.
 func BeIdenticalTo(expected interface{}) types.GomegaMatcher {
 	return &matchers.BeIdenticalToMatcher{
 		Expected: expected,
 	}
 }
 
-//BeNil succeeds if actual is nil
+// BeNil succeeds if actual is nil
 func BeNil() types.GomegaMatcher {
 	return &matchers.BeNilMatcher{}
 }
 
-//BeTrue succeeds if actual is true
+// BeTrue succeeds if actual is true
 func BeTrue() types.GomegaMatcher {
 	return &matchers.BeTrueMatcher{}
 }
 
-//BeFalse succeeds if actual is false
+// BeFalse succeeds if actual is false
 func BeFalse() types.GomegaMatcher {
 	return &matchers.BeFalseMatcher{}
 }
 
-//HaveOccurred succeeds if actual is a non-nil error
-//The typical Go error checking pattern looks like:
-//    err := SomethingThatMightFail()
-//    Expect(err).ShouldNot(HaveOccurred())
+// HaveOccurred succeeds if actual is a non-nil error
+// The typical Go error checking pattern looks like:
+//
+//	err := SomethingThatMightFail()
+//	Expect(err).ShouldNot(HaveOccurred())
 func HaveOccurred() types.GomegaMatcher {
 	return &matchers.HaveOccurredMatcher{}
 }
 
-//Succeed passes if actual is a nil error
-//Succeed is intended to be used with functions that return a single error value. Instead of
-//    err := SomethingThatMightFail()
-//    Expect(err).ShouldNot(HaveOccurred())
+// Succeed passes if actual is a nil error
+// Succeed is intended to be used with functions that return a single error value. Instead of
 //
-//You can write:
-//    Expect(SomethingThatMightFail()).Should(Succeed())
+//	err := SomethingThatMightFail()
+//	Expect(err).ShouldNot(HaveOccurred())
 //
-//It is a mistake to use Succeed with a function that has multiple return values.  Gomega's Ω and Expect
-//functions automatically trigger failure if any return values after the first return value are non-zero/non-nil.
-//This means that Ω(MultiReturnFunc()).ShouldNot(Succeed()) can never pass.
+// You can write:
+//
+//	Expect(SomethingThatMightFail()).Should(Succeed())
+//
+// It is a mistake to use Succeed with a function that has multiple return values.  Gomega's Ω and Expect
+// functions automatically trigger failure if any return values after the first return value are non-zero/non-nil.
+// This means that Ω(MultiReturnFunc()).ShouldNot(Succeed()) can never pass.
 func Succeed() types.GomegaMatcher {
 	return &matchers.SucceedMatcher{}
 }
 
-//MatchError succeeds if actual is a non-nil error that matches the passed in string/error.
+// MatchError succeeds if actual is a non-nil error that matches the passed in string/error.
 //
-//These are valid use-cases:
-//  Expect(err).Should(MatchError("an error")) //asserts that err.Error() == "an error"
-//  Expect(err).Should(MatchError(SomeError)) //asserts that err == SomeError (via reflect.DeepEqual)
+// These are valid use-cases:
 //
-//It is an error for err to be nil or an object that does not implement the Error interface
+//	Expect(err).Should(MatchError("an error")) //asserts that err.Error() == "an error"
+//	Expect(err).Should(MatchError(SomeError)) //asserts that err == SomeError (via reflect.DeepEqual)
+//
+// It is an error for err to be nil or an object that does not implement the Error interface
 func MatchError(expected interface{}) types.GomegaMatcher {
 	return &matchers.MatchErrorMatcher{
 		Expected: expected,
 	}
 }
 
-//BeClosed succeeds if actual is a closed channel.
-//It is an error to pass a non-channel to BeClosed, it is also an error to pass nil
+// BeClosed succeeds if actual is a closed channel.
+// It is an error to pass a non-channel to BeClosed, it is also an error to pass nil
 //
-//In order to check whether or not the channel is closed, Gomega must try to read from the channel
-//(even in the `ShouldNot(BeClosed())` case).  You should keep this in mind if you wish to make subsequent assertions about
-//values coming down the channel.
+// In order to check whether or not the channel is closed, Gomega must try to read from the channel
+// (even in the `ShouldNot(BeClosed())` case).  You should keep this in mind if you wish to make subsequent assertions about
+// values coming down the channel.
 //
-//Also, if you are testing that a *buffered* channel is closed you must first read all values out of the channel before
-//asserting that it is closed (it is not possible to detect that a buffered-channel has been closed until all its buffered values are read).
+// Also, if you are testing that a *buffered* channel is closed you must first read all values out of the channel before
+// asserting that it is closed (it is not possible to detect that a buffered-channel has been closed until all its buffered values are read).
 //
-//Finally, as a corollary: it is an error to check whether or not a send-only channel is closed.
+// Finally, as a corollary: it is an error to check whether or not a send-only channel is closed.
 func BeClosed() types.GomegaMatcher {
 	return &matchers.BeClosedMatcher{}
 }
 
-//Receive succeeds if there is a value to be received on actual.
-//Actual must be a channel (and cannot be a send-only channel) -- anything else is an error.
+// Receive succeeds if there is a value to be received on actual.
+// Actual must be a channel (and cannot be a send-only channel) -- anything else is an error.
 //
-//Receive returns immediately and never blocks:
+// Receive returns immediately and never blocks:
 //
-//- If there is nothing on the channel `c` then Expect(c).Should(Receive()) will fail and Ω(c).ShouldNot(Receive()) will pass.
+// - If there is nothing on the channel `c` then Expect(c).Should(Receive()) will fail and Ω(c).ShouldNot(Receive()) will pass.
 //
-//- If the channel `c` is closed then Expect(c).Should(Receive()) will fail and Ω(c).ShouldNot(Receive()) will pass.
+// - If the channel `c` is closed then Expect(c).Should(Receive()) will fail and Ω(c).ShouldNot(Receive()) will pass.
 //
-//- If there is something on the channel `c` ready to be read, then Expect(c).Should(Receive()) will pass and Ω(c).ShouldNot(Receive()) will fail.
+// - If there is something on the channel `c` ready to be read, then Expect(c).Should(Receive()) will pass and Ω(c).ShouldNot(Receive()) will fail.
 //
-//If you have a go-routine running in the background that will write to channel `c` you can:
-//    Eventually(c).Should(Receive())
+// If you have a go-routine running in the background that will write to channel `c` you can:
 //
-//This will timeout if nothing gets sent to `c` (you can modify the timeout interval as you normally do with `Eventually`)
+//	Eventually(c).Should(Receive())
 //
-//A similar use-case is to assert that no go-routine writes to a channel (for a period of time).  You can do this with `Consistently`:
-//    Consistently(c).ShouldNot(Receive())
+// This will timeout if nothing gets sent to `c` (you can modify the timeout interval as you normally do with `Eventually`)
 //
-//You can pass `Receive` a matcher.  If you do so, it will match the received object against the matcher.  For example:
-//    Expect(c).Should(Receive(Equal("foo")))
+// A similar use-case is to assert that no go-routine writes to a channel (for a period of time).  You can do this with `Consistently`:
 //
-//When given a matcher, `Receive` will always fail if there is nothing to be received on the channel.
+//	Consistently(c).ShouldNot(Receive())
 //
-//Passing Receive a matcher is especially useful when paired with Eventually:
+// You can pass `Receive` a matcher.  If you do so, it will match the received object against the matcher.  For example:
 //
-//    Eventually(c).Should(Receive(ContainSubstring("bar")))
+//	Expect(c).Should(Receive(Equal("foo")))
 //
-//will repeatedly attempt to pull values out of `c` until a value matching "bar" is received.
+// When given a matcher, `Receive` will always fail if there is nothing to be received on the channel.
 //
-//Finally, if you want to have a reference to the value *sent* to the channel you can pass the `Receive` matcher a pointer to a variable of the appropriate type:
-//    var myThing thing
-//    Eventually(thingChan).Should(Receive(&myThing))
-//    Expect(myThing.Sprocket).Should(Equal("foo"))
-//    Expect(myThing.IsValid()).Should(BeTrue())
+// Passing Receive a matcher is especially useful when paired with Eventually:
+//
+//	Eventually(c).Should(Receive(ContainSubstring("bar")))
+//
+// will repeatedly attempt to pull values out of `c` until a value matching "bar" is received.
+//
+// Finally, if you want to have a reference to the value *sent* to the channel you can pass the `Receive` matcher a pointer to a variable of the appropriate type:
+//
+//	var myThing thing
+//	Eventually(thingChan).Should(Receive(&myThing))
+//	Expect(myThing.Sprocket).Should(Equal("foo"))
+//	Expect(myThing.IsValid()).Should(BeTrue())
 func Receive(args ...interface{}) types.GomegaMatcher {
 	var arg interface{}
 	if len(args) > 0 {
@@ -157,27 +165,27 @@ func Receive(args ...interface{}) types.GomegaMatcher {
 	}
 }
 
-//BeSent succeeds if a value can be sent to actual.
-//Actual must be a channel (and cannot be a receive-only channel) that can sent the type of the value passed into BeSent -- anything else is an error.
-//In addition, actual must not be closed.
+// BeSent succeeds if a value can be sent to actual.
+// Actual must be a channel (and cannot be a receive-only channel) that can sent the type of the value passed into BeSent -- anything else is an error.
+// In addition, actual must not be closed.
 //
-//BeSent never blocks:
+// BeSent never blocks:
 //
-//- If the channel `c` is not ready to receive then Expect(c).Should(BeSent("foo")) will fail immediately
-//- If the channel `c` is eventually ready to receive then Eventually(c).Should(BeSent("foo")) will succeed.. presuming the channel becomes ready to receive  before Eventually's timeout
-//- If the channel `c` is closed then Expect(c).Should(BeSent("foo")) and Ω(c).ShouldNot(BeSent("foo")) will both fail immediately
+// - If the channel `c` is not ready to receive then Expect(c).Should(BeSent("foo")) will fail immediately
+// - If the channel `c` is eventually ready to receive then Eventually(c).Should(BeSent("foo")) will succeed.. presuming the channel becomes ready to receive  before Eventually's timeout
+// - If the channel `c` is closed then Expect(c).Should(BeSent("foo")) and Ω(c).ShouldNot(BeSent("foo")) will both fail immediately
 //
-//Of course, the value is actually sent to the channel.  The point of `BeSent` is less to make an assertion about the availability of the channel (which is typically an implementation detail that your test should not be concerned with).
-//Rather, the point of `BeSent` is to make it possible to easily and expressively write tests that can timeout on blocked channel sends.
+// Of course, the value is actually sent to the channel.  The point of `BeSent` is less to make an assertion about the availability of the channel (which is typically an implementation detail that your test should not be concerned with).
+// Rather, the point of `BeSent` is to make it possible to easily and expressively write tests that can timeout on blocked channel sends.
 func BeSent(arg interface{}) types.GomegaMatcher {
 	return &matchers.BeSentMatcher{
 		Arg: arg,
 	}
 }
 
-//MatchRegexp succeeds if actual is a string or stringer that matches the
-//passed-in regexp.  Optional arguments can be provided to construct a regexp
-//via fmt.Sprintf().
+// MatchRegexp succeeds if actual is a string or stringer that matches the
+// passed-in regexp.  Optional arguments can be provided to construct a regexp
+// via fmt.Sprintf().
 func MatchRegexp(regexp string, args ...interface{}) types.GomegaMatcher {
 	return &matchers.MatchRegexpMatcher{
 		Regexp: regexp,
@@ -185,9 +193,9 @@ func MatchRegexp(regexp string, args ...interface{}) types.GomegaMatcher {
 	}
 }
 
-//ContainSubstring succeeds if actual is a string or stringer that contains the
-//passed-in substring.  Optional arguments can be provided to construct the substring
-//via fmt.Sprintf().
+// ContainSubstring succeeds if actual is a string or stringer that contains the
+// passed-in substring.  Optional arguments can be provided to construct the substring
+// via fmt.Sprintf().
 func ContainSubstring(substr string, args ...interface{}) types.GomegaMatcher {
 	return &matchers.ContainSubstringMatcher{
 		Substr: substr,
@@ -195,9 +203,9 @@ func ContainSubstring(substr string, args ...interface{}) types.GomegaMatcher {
 	}
 }
 
-//HavePrefix succeeds if actual is a string or stringer that contains the
-//passed-in string as a prefix.  Optional arguments can be provided to construct
-//via fmt.Sprintf().
+// HavePrefix succeeds if actual is a string or stringer that contains the
+// passed-in string as a prefix.  Optional arguments can be provided to construct
+// via fmt.Sprintf().
 func HavePrefix(prefix string, args ...interface{}) types.GomegaMatcher {
 	return &matchers.HavePrefixMatcher{
 		Prefix: prefix,
@@ -205,9 +213,9 @@ func HavePrefix(prefix string, args ...interface{}) types.GomegaMatcher {
 	}
 }
 
-//HaveSuffix succeeds if actual is a string or stringer that contains the
-//passed-in string as a suffix.  Optional arguments can be provided to construct
-//via fmt.Sprintf().
+// HaveSuffix succeeds if actual is a string or stringer that contains the
+// passed-in string as a suffix.  Optional arguments can be provided to construct
+// via fmt.Sprintf().
 func HaveSuffix(suffix string, args ...interface{}) types.GomegaMatcher {
 	return &matchers.HaveSuffixMatcher{
 		Suffix: suffix,
@@ -215,73 +223,74 @@ func HaveSuffix(suffix string, args ...interface{}) types.GomegaMatcher {
 	}
 }
 
-//MatchJSON succeeds if actual is a string or stringer of JSON that matches
-//the expected JSON.  The JSONs are decoded and the resulting objects are compared via
-//reflect.DeepEqual so things like key-ordering and whitespace shouldn't matter.
+// MatchJSON succeeds if actual is a string or stringer of JSON that matches
+// the expected JSON.  The JSONs are decoded and the resulting objects are compared via
+// reflect.DeepEqual so things like key-ordering and whitespace shouldn't matter.
 func MatchJSON(json interface{}) types.GomegaMatcher {
 	return &matchers.MatchJSONMatcher{
 		JSONToMatch: json,
 	}
 }
 
-//MatchXML succeeds if actual is a string or stringer of XML that matches
-//the expected XML.  The XMLs are decoded and the resulting objects are compared via
-//reflect.DeepEqual so things like whitespaces shouldn't matter.
+// MatchXML succeeds if actual is a string or stringer of XML that matches
+// the expected XML.  The XMLs are decoded and the resulting objects are compared via
+// reflect.DeepEqual so things like whitespaces shouldn't matter.
 func MatchXML(xml interface{}) types.GomegaMatcher {
 	return &matchers.MatchXMLMatcher{
 		XMLToMatch: xml,
 	}
 }
 
-//MatchYAML succeeds if actual is a string or stringer of YAML that matches
-//the expected YAML.  The YAML's are decoded and the resulting objects are compared via
-//reflect.DeepEqual so things like key-ordering and whitespace shouldn't matter.
+// MatchYAML succeeds if actual is a string or stringer of YAML that matches
+// the expected YAML.  The YAML's are decoded and the resulting objects are compared via
+// reflect.DeepEqual so things like key-ordering and whitespace shouldn't matter.
 func MatchYAML(yaml interface{}) types.GomegaMatcher {
 	return &matchers.MatchYAMLMatcher{
 		YAMLToMatch: yaml,
 	}
 }
 
-//BeEmpty succeeds if actual is empty.  Actual must be of type string, array, map, chan, or slice.
+// BeEmpty succeeds if actual is empty.  Actual must be of type string, array, map, chan, or slice.
 func BeEmpty() types.GomegaMatcher {
 	return &matchers.BeEmptyMatcher{}
 }
 
-//HaveLen succeeds if actual has the passed-in length.  Actual must be of type string, array, map, chan, or slice.
+// HaveLen succeeds if actual has the passed-in length.  Actual must be of type string, array, map, chan, or slice.
 func HaveLen(count int) types.GomegaMatcher {
 	return &matchers.HaveLenMatcher{
 		Count: count,
 	}
 }
 
-//HaveCap succeeds if actual has the passed-in capacity.  Actual must be of type array, chan, or slice.
+// HaveCap succeeds if actual has the passed-in capacity.  Actual must be of type array, chan, or slice.
 func HaveCap(count int) types.GomegaMatcher {
 	return &matchers.HaveCapMatcher{
 		Count: count,
 	}
 }
 
-//BeZero succeeds if actual is the zero value for its type or if actual is nil.
+// BeZero succeeds if actual is the zero value for its type or if actual is nil.
 func BeZero() types.GomegaMatcher {
 	return &matchers.BeZeroMatcher{}
 }
 
-//ContainElement succeeds if actual contains the passed in element. By default
-//ContainElement() uses Equal() to perform the match, however a matcher can be
-//passed in instead:
-//    Expect([]string{"Foo", "FooBar"}).Should(ContainElement(ContainSubstring("Bar")))
+// ContainElement succeeds if actual contains the passed in element. By default
+// ContainElement() uses Equal() to perform the match, however a matcher can be
+// passed in instead:
 //
-//Actual must be an array, slice or map. For maps, ContainElement searches
-//through the map's values.
+//	Expect([]string{"Foo", "FooBar"}).Should(ContainElement(ContainSubstring("Bar")))
 //
-//If you want to have a copy of the matching element(s) found you can pass a
-//pointer to a variable of the appropriate type. If the variable isn't a slice
-//or map, then exactly one match will be expected and returned. If the variable
-//is a slice or map, then at least one match is expected and all matches will be
-//stored in the variable.
+// Actual must be an array, slice or map. For maps, ContainElement searches
+// through the map's values.
 //
-//    var findings []string
-//    Expect([]string{"Foo", "FooBar"}).Should(ContainElement(ContainSubString("Bar", &findings)))
+// If you want to have a copy of the matching element(s) found you can pass a
+// pointer to a variable of the appropriate type. If the variable isn't a slice
+// or map, then exactly one match will be expected and returned. If the variable
+// is a slice or map, then at least one match is expected and all matches will be
+// stored in the variable.
+//
+//	var findings []string
+//	Expect([]string{"Foo", "FooBar"}).Should(ContainElement(ContainSubString("Bar", &findings)))
 func ContainElement(element interface{}, result ...interface{}) types.GomegaMatcher {
 	return &matchers.ContainElementMatcher{
 		Element: element,
@@ -289,86 +298,102 @@ func ContainElement(element interface{}, result ...interface{}) types.GomegaMatc
 	}
 }
 
-//BeElementOf succeeds if actual is contained in the passed in elements.
-//BeElementOf() always uses Equal() to perform the match.
-//When the passed in elements are comprised of a single element that is either an Array or Slice, BeElementOf() behaves
-//as the reverse of ContainElement() that operates with Equal() to perform the match.
-//    Expect(2).Should(BeElementOf([]int{1, 2}))
-//    Expect(2).Should(BeElementOf([2]int{1, 2}))
-//Otherwise, BeElementOf() provides a syntactic sugar for Or(Equal(_), Equal(_), ...):
-//    Expect(2).Should(BeElementOf(1, 2))
+// BeElementOf succeeds if actual is contained in the passed in elements.
+// BeElementOf() always uses Equal() to perform the match.
+// When the passed in elements are comprised of a single element that is either an Array or Slice, BeElementOf() behaves
+// as the reverse of ContainElement() that operates with Equal() to perform the match.
 //
-//Actual must be typed.
+//	Expect(2).Should(BeElementOf([]int{1, 2}))
+//	Expect(2).Should(BeElementOf([2]int{1, 2}))
+//
+// Otherwise, BeElementOf() provides a syntactic sugar for Or(Equal(_), Equal(_), ...):
+//
+//	Expect(2).Should(BeElementOf(1, 2))
+//
+// Actual must be typed.
 func BeElementOf(elements ...interface{}) types.GomegaMatcher {
 	return &matchers.BeElementOfMatcher{
 		Elements: elements,
 	}
 }
 
-//ConsistOf succeeds if actual contains precisely the elements passed into the matcher.  The ordering of the elements does not matter.
-//By default ConsistOf() uses Equal() to match the elements, however custom matchers can be passed in instead.  Here are some examples:
+// BeKeyOf succeeds if actual is contained in the keys of the passed in map.
+// BeKeyOf() always uses Equal() to perform the match between actual and the map keys.
 //
-//    Expect([]string{"Foo", "FooBar"}).Should(ConsistOf("FooBar", "Foo"))
-//    Expect([]string{"Foo", "FooBar"}).Should(ConsistOf(ContainSubstring("Bar"), "Foo"))
-//    Expect([]string{"Foo", "FooBar"}).Should(ConsistOf(ContainSubstring("Foo"), ContainSubstring("Foo")))
+//	Expect("foo").Should(BeKeyOf(map[string]bool{"foo": true, "bar": false}))
+func BeKeyOf(element interface{}) types.GomegaMatcher {
+	return &matchers.BeKeyOfMatcher{
+		Map: element,
+	}
+}
+
+// ConsistOf succeeds if actual contains precisely the elements passed into the matcher.  The ordering of the elements does not matter.
+// By default ConsistOf() uses Equal() to match the elements, however custom matchers can be passed in instead.  Here are some examples:
 //
-//Actual must be an array, slice or map.  For maps, ConsistOf matches against the map's values.
+//	Expect([]string{"Foo", "FooBar"}).Should(ConsistOf("FooBar", "Foo"))
+//	Expect([]string{"Foo", "FooBar"}).Should(ConsistOf(ContainSubstring("Bar"), "Foo"))
+//	Expect([]string{"Foo", "FooBar"}).Should(ConsistOf(ContainSubstring("Foo"), ContainSubstring("Foo")))
 //
-//You typically pass variadic arguments to ConsistOf (as in the examples above).  However, if you need to pass in a slice you can provided that it
-//is the only element passed in to ConsistOf:
+// Actual must be an array, slice or map.  For maps, ConsistOf matches against the map's values.
 //
-//    Expect([]string{"Foo", "FooBar"}).Should(ConsistOf([]string{"FooBar", "Foo"}))
+// You typically pass variadic arguments to ConsistOf (as in the examples above).  However, if you need to pass in a slice you can provided that it
+// is the only element passed in to ConsistOf:
 //
-//Note that Go's type system does not allow you to write this as ConsistOf([]string{"FooBar", "Foo"}...) as []string and []interface{} are different types - hence the need for this special rule.
+//	Expect([]string{"Foo", "FooBar"}).Should(ConsistOf([]string{"FooBar", "Foo"}))
+//
+// Note that Go's type system does not allow you to write this as ConsistOf([]string{"FooBar", "Foo"}...) as []string and []interface{} are different types - hence the need for this special rule.
 func ConsistOf(elements ...interface{}) types.GomegaMatcher {
 	return &matchers.ConsistOfMatcher{
 		Elements: elements,
 	}
 }
 
-//ContainElements succeeds if actual contains the passed in elements. The ordering of the elements does not matter.
-//By default ContainElements() uses Equal() to match the elements, however custom matchers can be passed in instead. Here are some examples:
+// ContainElements succeeds if actual contains the passed in elements. The ordering of the elements does not matter.
+// By default ContainElements() uses Equal() to match the elements, however custom matchers can be passed in instead. Here are some examples:
 //
-//    Expect([]string{"Foo", "FooBar"}).Should(ContainElements("FooBar"))
-//    Expect([]string{"Foo", "FooBar"}).Should(ContainElements(ContainSubstring("Bar"), "Foo"))
+//	Expect([]string{"Foo", "FooBar"}).Should(ContainElements("FooBar"))
+//	Expect([]string{"Foo", "FooBar"}).Should(ContainElements(ContainSubstring("Bar"), "Foo"))
 //
-//Actual must be an array, slice or map.
-//For maps, ContainElements searches through the map's values.
+// Actual must be an array, slice or map.
+// For maps, ContainElements searches through the map's values.
 func ContainElements(elements ...interface{}) types.GomegaMatcher {
 	return &matchers.ContainElementsMatcher{
 		Elements: elements,
 	}
 }
 
-//HaveEach succeeds if actual solely contains elements that match the passed in element.
-//Please note that if actual is empty, HaveEach always will succeed.
-//By default HaveEach() uses Equal() to perform the match, however a
-//matcher can be passed in instead:
-//    Expect([]string{"Foo", "FooBar"}).Should(HaveEach(ContainSubstring("Foo")))
+// HaveEach succeeds if actual solely contains elements that match the passed in element.
+// Please note that if actual is empty, HaveEach always will succeed.
+// By default HaveEach() uses Equal() to perform the match, however a
+// matcher can be passed in instead:
 //
-//Actual must be an array, slice or map.
-//For maps, HaveEach searches through the map's values.
+//	Expect([]string{"Foo", "FooBar"}).Should(HaveEach(ContainSubstring("Foo")))
+//
+// Actual must be an array, slice or map.
+// For maps, HaveEach searches through the map's values.
 func HaveEach(element interface{}) types.GomegaMatcher {
 	return &matchers.HaveEachMatcher{
 		Element: element,
 	}
 }
 
-//HaveKey succeeds if actual is a map with the passed in key.
-//By default HaveKey uses Equal() to perform the match, however a
-//matcher can be passed in instead:
-//    Expect(map[string]string{"Foo": "Bar", "BazFoo": "Duck"}).Should(HaveKey(MatchRegexp(`.+Foo$`)))
+// HaveKey succeeds if actual is a map with the passed in key.
+// By default HaveKey uses Equal() to perform the match, however a
+// matcher can be passed in instead:
+//
+//	Expect(map[string]string{"Foo": "Bar", "BazFoo": "Duck"}).Should(HaveKey(MatchRegexp(`.+Foo$`)))
 func HaveKey(key interface{}) types.GomegaMatcher {
 	return &matchers.HaveKeyMatcher{
 		Key: key,
 	}
 }
 
-//HaveKeyWithValue succeeds if actual is a map with the passed in key and value.
-//By default HaveKeyWithValue uses Equal() to perform the match, however a
-//matcher can be passed in instead:
-//    Expect(map[string]string{"Foo": "Bar", "BazFoo": "Duck"}).Should(HaveKeyWithValue("Foo", "Bar"))
-//    Expect(map[string]string{"Foo": "Bar", "BazFoo": "Duck"}).Should(HaveKeyWithValue(MatchRegexp(`.+Foo$`), "Bar"))
+// HaveKeyWithValue succeeds if actual is a map with the passed in key and value.
+// By default HaveKeyWithValue uses Equal() to perform the match, however a
+// matcher can be passed in instead:
+//
+//	Expect(map[string]string{"Foo": "Bar", "BazFoo": "Duck"}).Should(HaveKeyWithValue("Foo", "Bar"))
+//	Expect(map[string]string{"Foo": "Bar", "BazFoo": "Duck"}).Should(HaveKeyWithValue(MatchRegexp(`.+Foo$`), "Bar"))
 func HaveKeyWithValue(key interface{}, value interface{}) types.GomegaMatcher {
 	return &matchers.HaveKeyWithValueMatcher{
 		Key:   key,
@@ -376,27 +401,27 @@ func HaveKeyWithValue(key interface{}, value interface{}) types.GomegaMatcher {
 	}
 }
 
-//HaveField succeeds if actual is a struct and the value at the passed in field
-//matches the passed in matcher.  By default HaveField used Equal() to perform the match,
-//however a matcher can be passed in in stead.
+// HaveField succeeds if actual is a struct and the value at the passed in field
+// matches the passed in matcher.  By default HaveField used Equal() to perform the match,
+// however a matcher can be passed in in stead.
 //
-//The field must be a string that resolves to the name of a field in the struct.  Structs can be traversed
-//using the '.' delimiter.  If the field ends with '()' a method named field is assumed to exist on the struct and is invoked.
-//Such methods must take no arguments and return a single value:
+// The field must be a string that resolves to the name of a field in the struct.  Structs can be traversed
+// using the '.' delimiter.  If the field ends with '()' a method named field is assumed to exist on the struct and is invoked.
+// Such methods must take no arguments and return a single value:
 //
-//    type Book struct {
-//        Title string
-//        Author Person
-//    }
-//    type Person struct {
-//        FirstName string
-//        LastName string
-//        DOB time.Time
-//    }
-//    Expect(book).To(HaveField("Title", "Les Miserables"))
-//    Expect(book).To(HaveField("Title", ContainSubstring("Les"))
-//    Expect(book).To(HaveField("Author.FirstName", Equal("Victor"))
-//    Expect(book).To(HaveField("Author.DOB.Year()", BeNumerically("<", 1900))
+//	type Book struct {
+//	    Title string
+//	    Author Person
+//	}
+//	type Person struct {
+//	    FirstName string
+//	    LastName string
+//	    DOB time.Time
+//	}
+//	Expect(book).To(HaveField("Title", "Les Miserables"))
+//	Expect(book).To(HaveField("Title", ContainSubstring("Les"))
+//	Expect(book).To(HaveField("Author.FirstName", Equal("Victor"))
+//	Expect(book).To(HaveField("Author.DOB.Year()", BeNumerically("<", 1900))
 func HaveField(field string, expected interface{}) types.GomegaMatcher {
 	return &matchers.HaveFieldMatcher{
 		Field:    field,
@@ -410,7 +435,7 @@ func HaveField(field string, expected interface{}) types.GomegaMatcher {
 // HaveExistingField can be combined with HaveField in order to cover use cases
 // with optional fields. HaveField alone would trigger an error in such situations.
 //
-//     Expect(MrHarmless).NotTo(And(HaveExistingField("Title"), HaveField("Title", "Supervillain")))
+//	Expect(MrHarmless).NotTo(And(HaveExistingField("Title"), HaveField("Title", "Supervillain")))
 func HaveExistingField(field string) types.GomegaMatcher {
 	return &matchers.HaveExistingFieldMatcher{
 		Field: field,
@@ -428,26 +453,27 @@ func HaveExistingField(field string) types.GomegaMatcher {
 // be a pointer (as gstruct.PointTo does) but instead also accepts non-pointer
 // and even interface values.
 //
-//   actual := 42
-//   Expect(actual).To(HaveValue(42))
-//   Expect(&actual).To(HaveValue(42))
+//	actual := 42
+//	Expect(actual).To(HaveValue(42))
+//	Expect(&actual).To(HaveValue(42))
 func HaveValue(matcher types.GomegaMatcher) types.GomegaMatcher {
 	return &matchers.HaveValueMatcher{
 		Matcher: matcher,
 	}
 }
 
-//BeNumerically performs numerical assertions in a type-agnostic way.
-//Actual and expected should be numbers, though the specific type of
-//number is irrelevant (float32, float64, uint8, etc...).
+// BeNumerically performs numerical assertions in a type-agnostic way.
+// Actual and expected should be numbers, though the specific type of
+// number is irrelevant (float32, float64, uint8, etc...).
 //
-//There are six, self-explanatory, supported comparators:
-//    Expect(1.0).Should(BeNumerically("==", 1))
-//    Expect(1.0).Should(BeNumerically("~", 0.999, 0.01))
-//    Expect(1.0).Should(BeNumerically(">", 0.9))
-//    Expect(1.0).Should(BeNumerically(">=", 1.0))
-//    Expect(1.0).Should(BeNumerically("<", 3))
-//    Expect(1.0).Should(BeNumerically("<=", 1.0))
+// There are six, self-explanatory, supported comparators:
+//
+//	Expect(1.0).Should(BeNumerically("==", 1))
+//	Expect(1.0).Should(BeNumerically("~", 0.999, 0.01))
+//	Expect(1.0).Should(BeNumerically(">", 0.9))
+//	Expect(1.0).Should(BeNumerically(">=", 1.0))
+//	Expect(1.0).Should(BeNumerically("<", 3))
+//	Expect(1.0).Should(BeNumerically("<=", 1.0))
 func BeNumerically(comparator string, compareTo ...interface{}) types.GomegaMatcher {
 	return &matchers.BeNumericallyMatcher{
 		Comparator: comparator,
@@ -455,10 +481,11 @@ func BeNumerically(comparator string, compareTo ...interface{}) types.GomegaMatc
 	}
 }
 
-//BeTemporally compares time.Time's like BeNumerically
-//Actual and expected must be time.Time. The comparators are the same as for BeNumerically
-//    Expect(time.Now()).Should(BeTemporally(">", time.Time{}))
-//    Expect(time.Now()).Should(BeTemporally("~", time.Now(), time.Second))
+// BeTemporally compares time.Time's like BeNumerically
+// Actual and expected must be time.Time. The comparators are the same as for BeNumerically
+//
+//	Expect(time.Now()).Should(BeTemporally(">", time.Time{}))
+//	Expect(time.Now()).Should(BeTemporally("~", time.Now(), time.Second))
 func BeTemporally(comparator string, compareTo time.Time, threshold ...time.Duration) types.GomegaMatcher {
 	return &matchers.BeTemporallyMatcher{
 		Comparator: comparator,
@@ -467,58 +494,61 @@ func BeTemporally(comparator string, compareTo time.Time, threshold ...time.Dura
 	}
 }
 
-//BeAssignableToTypeOf succeeds if actual is assignable to the type of expected.
-//It will return an error when one of the values is nil.
-//    Expect(0).Should(BeAssignableToTypeOf(0))         // Same values
-//    Expect(5).Should(BeAssignableToTypeOf(-1))        // different values same type
-//    Expect("foo").Should(BeAssignableToTypeOf("bar")) // different values same type
-//    Expect(struct{ Foo string }{}).Should(BeAssignableToTypeOf(struct{ Foo string }{}))
+// BeAssignableToTypeOf succeeds if actual is assignable to the type of expected.
+// It will return an error when one of the values is nil.
+//
+//	Expect(0).Should(BeAssignableToTypeOf(0))         // Same values
+//	Expect(5).Should(BeAssignableToTypeOf(-1))        // different values same type
+//	Expect("foo").Should(BeAssignableToTypeOf("bar")) // different values same type
+//	Expect(struct{ Foo string }{}).Should(BeAssignableToTypeOf(struct{ Foo string }{}))
 func BeAssignableToTypeOf(expected interface{}) types.GomegaMatcher {
 	return &matchers.AssignableToTypeOfMatcher{
 		Expected: expected,
 	}
 }
 
-//Panic succeeds if actual is a function that, when invoked, panics.
-//Actual must be a function that takes no arguments and returns no results.
+// Panic succeeds if actual is a function that, when invoked, panics.
+// Actual must be a function that takes no arguments and returns no results.
 func Panic() types.GomegaMatcher {
 	return &matchers.PanicMatcher{}
 }
 
-//PanicWith succeeds if actual is a function that, when invoked, panics with a specific value.
-//Actual must be a function that takes no arguments and returns no results.
+// PanicWith succeeds if actual is a function that, when invoked, panics with a specific value.
+// Actual must be a function that takes no arguments and returns no results.
 //
-//By default PanicWith uses Equal() to perform the match, however a
-//matcher can be passed in instead:
-//    Expect(fn).Should(PanicWith(MatchRegexp(`.+Foo$`)))
+// By default PanicWith uses Equal() to perform the match, however a
+// matcher can be passed in instead:
+//
+//	Expect(fn).Should(PanicWith(MatchRegexp(`.+Foo$`)))
 func PanicWith(expected interface{}) types.GomegaMatcher {
 	return &matchers.PanicMatcher{Expected: expected}
 }
 
-//BeAnExistingFile succeeds if a file exists.
-//Actual must be a string representing the abs path to the file being checked.
+// BeAnExistingFile succeeds if a file exists.
+// Actual must be a string representing the abs path to the file being checked.
 func BeAnExistingFile() types.GomegaMatcher {
 	return &matchers.BeAnExistingFileMatcher{}
 }
 
-//BeARegularFile succeeds if a file exists and is a regular file.
-//Actual must be a string representing the abs path to the file being checked.
+// BeARegularFile succeeds if a file exists and is a regular file.
+// Actual must be a string representing the abs path to the file being checked.
 func BeARegularFile() types.GomegaMatcher {
 	return &matchers.BeARegularFileMatcher{}
 }
 
-//BeADirectory succeeds if a file exists and is a directory.
-//Actual must be a string representing the abs path to the file being checked.
+// BeADirectory succeeds if a file exists and is a directory.
+// Actual must be a string representing the abs path to the file being checked.
 func BeADirectory() types.GomegaMatcher {
 	return &matchers.BeADirectoryMatcher{}
 }
 
-//HaveHTTPStatus succeeds if the Status or StatusCode field of an HTTP response matches.
-//Actual must be either a *http.Response or *httptest.ResponseRecorder.
-//Expected must be either an int or a string.
-//  Expect(resp).Should(HaveHTTPStatus(http.StatusOK))   // asserts that resp.StatusCode == 200
-//  Expect(resp).Should(HaveHTTPStatus("404 Not Found")) // asserts that resp.Status == "404 Not Found"
-//  Expect(resp).Should(HaveHTTPStatus(http.StatusOK, http.StatusNoContent))   // asserts that resp.StatusCode == 200 || resp.StatusCode == 204
+// HaveHTTPStatus succeeds if the Status or StatusCode field of an HTTP response matches.
+// Actual must be either a *http.Response or *httptest.ResponseRecorder.
+// Expected must be either an int or a string.
+//
+//	Expect(resp).Should(HaveHTTPStatus(http.StatusOK))   // asserts that resp.StatusCode == 200
+//	Expect(resp).Should(HaveHTTPStatus("404 Not Found")) // asserts that resp.Status == "404 Not Found"
+//	Expect(resp).Should(HaveHTTPStatus(http.StatusOK, http.StatusNoContent))   // asserts that resp.StatusCode == 200 || resp.StatusCode == 204
 func HaveHTTPStatus(expected ...interface{}) types.GomegaMatcher {
 	return &matchers.HaveHTTPStatusMatcher{Expected: expected}
 }
@@ -541,63 +571,70 @@ func HaveHTTPBody(expected interface{}) types.GomegaMatcher {
 	return &matchers.HaveHTTPBodyMatcher{Expected: expected}
 }
 
-//And succeeds only if all of the given matchers succeed.
-//The matchers are tried in order, and will fail-fast if one doesn't succeed.
-//  Expect("hi").To(And(HaveLen(2), Equal("hi"))
+// And succeeds only if all of the given matchers succeed.
+// The matchers are tried in order, and will fail-fast if one doesn't succeed.
 //
-//And(), Or(), Not() and WithTransform() allow matchers to be composed into complex expressions.
+//	Expect("hi").To(And(HaveLen(2), Equal("hi"))
+//
+// And(), Or(), Not() and WithTransform() allow matchers to be composed into complex expressions.
 func And(ms ...types.GomegaMatcher) types.GomegaMatcher {
 	return &matchers.AndMatcher{Matchers: ms}
 }
 
-//SatisfyAll is an alias for And().
-//  Expect("hi").Should(SatisfyAll(HaveLen(2), Equal("hi")))
+// SatisfyAll is an alias for And().
+//
+//	Expect("hi").Should(SatisfyAll(HaveLen(2), Equal("hi")))
 func SatisfyAll(matchers ...types.GomegaMatcher) types.GomegaMatcher {
 	return And(matchers...)
 }
 
-//Or succeeds if any of the given matchers succeed.
-//The matchers are tried in order and will return immediately upon the first successful match.
-//  Expect("hi").To(Or(HaveLen(3), HaveLen(2))
+// Or succeeds if any of the given matchers succeed.
+// The matchers are tried in order and will return immediately upon the first successful match.
 //
-//And(), Or(), Not() and WithTransform() allow matchers to be composed into complex expressions.
+//	Expect("hi").To(Or(HaveLen(3), HaveLen(2))
+//
+// And(), Or(), Not() and WithTransform() allow matchers to be composed into complex expressions.
 func Or(ms ...types.GomegaMatcher) types.GomegaMatcher {
 	return &matchers.OrMatcher{Matchers: ms}
 }
 
-//SatisfyAny is an alias for Or().
-//  Expect("hi").SatisfyAny(Or(HaveLen(3), HaveLen(2))
+// SatisfyAny is an alias for Or().
+//
+//	Expect("hi").SatisfyAny(Or(HaveLen(3), HaveLen(2))
 func SatisfyAny(matchers ...types.GomegaMatcher) types.GomegaMatcher {
 	return Or(matchers...)
 }
 
-//Not negates the given matcher; it succeeds if the given matcher fails.
-//  Expect(1).To(Not(Equal(2))
+// Not negates the given matcher; it succeeds if the given matcher fails.
 //
-//And(), Or(), Not() and WithTransform() allow matchers to be composed into complex expressions.
+//	Expect(1).To(Not(Equal(2))
+//
+// And(), Or(), Not() and WithTransform() allow matchers to be composed into complex expressions.
 func Not(matcher types.GomegaMatcher) types.GomegaMatcher {
 	return &matchers.NotMatcher{Matcher: matcher}
 }
 
-//WithTransform applies the `transform` to the actual value and matches it against `matcher`.
-//The given transform must be either a function of one parameter that returns one value or a
+// WithTransform applies the `transform` to the actual value and matches it against `matcher`.
+// The given transform must be either a function of one parameter that returns one value or a
 // function of one parameter that returns two values, where the second value must be of the
 // error type.
-//  var plus1 = func(i int) int { return i + 1 }
-//  Expect(1).To(WithTransform(plus1, Equal(2))
 //
-//   var failingplus1 = func(i int) (int, error) { return 42, "this does not compute" }
-//   Expect(1).To(WithTransform(failingplus1, Equal(2)))
+//	var plus1 = func(i int) int { return i + 1 }
+//	Expect(1).To(WithTransform(plus1, Equal(2))
 //
-//And(), Or(), Not() and WithTransform() allow matchers to be composed into complex expressions.
+//	 var failingplus1 = func(i int) (int, error) { return 42, "this does not compute" }
+//	 Expect(1).To(WithTransform(failingplus1, Equal(2)))
+//
+// And(), Or(), Not() and WithTransform() allow matchers to be composed into complex expressions.
 func WithTransform(transform interface{}, matcher types.GomegaMatcher) types.GomegaMatcher {
 	return matchers.NewWithTransformMatcher(transform, matcher)
 }
 
-//Satisfy matches the actual value against the `predicate` function.
-//The given predicate must be a function of one paramter that returns bool.
-//  var isEven = func(i int) bool { return i%2 == 0 }
-//  Expect(2).To(Satisfy(isEven))
+// Satisfy matches the actual value against the `predicate` function.
+// The given predicate must be a function of one paramter that returns bool.
+//
+//	var isEven = func(i int) bool { return i%2 == 0 }
+//	Expect(2).To(Satisfy(isEven))
 func Satisfy(predicate interface{}) types.GomegaMatcher {
 	return matchers.NewSatisfyMatcher(predicate)
 }

--- a/vendor/github.com/onsi/gomega/matchers/be_key_of_matcher.go
+++ b/vendor/github.com/onsi/gomega/matchers/be_key_of_matcher.go
@@ -1,0 +1,45 @@
+package matchers
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/onsi/gomega/format"
+)
+
+type BeKeyOfMatcher struct {
+	Map interface{}
+}
+
+func (matcher *BeKeyOfMatcher) Match(actual interface{}) (success bool, err error) {
+	if !isMap(matcher.Map) {
+		return false, fmt.Errorf("BeKeyOf matcher needs expected to be a map type")
+	}
+
+	if reflect.TypeOf(actual) == nil {
+		return false, fmt.Errorf("BeKeyOf matcher expects actual to be typed")
+	}
+
+	var lastError error
+	for _, key := range reflect.ValueOf(matcher.Map).MapKeys() {
+		matcher := &EqualMatcher{Expected: key.Interface()}
+		success, err := matcher.Match(actual)
+		if err != nil {
+			lastError = err
+			continue
+		}
+		if success {
+			return true, nil
+		}
+	}
+
+	return false, lastError
+}
+
+func (matcher *BeKeyOfMatcher) FailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "to be a key of", presentable(valuesOf(matcher.Map)))
+}
+
+func (matcher *BeKeyOfMatcher) NegatedFailureMessage(actual interface{}) (message string) {
+	return format.Message(actual, "not to be a key of", presentable(valuesOf(matcher.Map)))
+}

--- a/vendor/github.com/onsi/gomega/types/types.go
+++ b/vendor/github.com/onsi/gomega/types/types.go
@@ -1,12 +1,13 @@
 package types
 
 import (
+	"context"
 	"time"
 )
 
 type GomegaFailHandler func(message string, callerSkip ...int)
 
-//A simple *testing.T interface wrapper
+// A simple *testing.T interface wrapper
 type GomegaTestingT interface {
 	Helper()
 	Fatalf(format string, args ...interface{})
@@ -30,9 +31,9 @@ type Gomega interface {
 	SetDefaultConsistentlyPollingInterval(time.Duration)
 }
 
-//All Gomega matchers must implement the GomegaMatcher interface
+// All Gomega matchers must implement the GomegaMatcher interface
 //
-//For details on writing custom matchers, check out: http://onsi.github.io/gomega/#adding-your-own-matchers
+// For details on writing custom matchers, check out: http://onsi.github.io/gomega/#adding-your-own-matchers
 type GomegaMatcher interface {
 	Match(actual interface{}) (success bool, err error)
 	FailureMessage(actual interface{}) (message string)
@@ -70,6 +71,9 @@ type AsyncAssertion interface {
 	WithOffset(offset int) AsyncAssertion
 	WithTimeout(interval time.Duration) AsyncAssertion
 	WithPolling(interval time.Duration) AsyncAssertion
+	Within(timeout time.Duration) AsyncAssertion
+	ProbeEvery(interval time.Duration) AsyncAssertion
+	WithContext(ctx context.Context) AsyncAssertion
 }
 
 // Assertions are returned by Ω and Expect and enable assertions against Gomega matchers

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -800,7 +800,7 @@ github.com/onsi/ginkgo/v2/internal/parallel_support
 github.com/onsi/ginkgo/v2/internal/testingtproxy
 github.com/onsi/ginkgo/v2/reporters
 github.com/onsi/ginkgo/v2/types
-# github.com/onsi/gomega v1.20.2
+# github.com/onsi/gomega v1.21.1
 ## explicit; go 1.18
 github.com/onsi/gomega
 github.com/onsi/gomega/format


### PR DESCRIPTION
Linters 'deadcode', 'varchar' and 'structcheck' have all been deprecated and
replaced by 'unused'.
