### PR TITLE
[BUILD] - Github Action Update (Upload Artifacts)

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -54,7 +54,7 @@ jobs:
           tags: ghcr.io/appvia/terranetes-controller:ci
           outputs: type=docker,dest=/tmp/controller-image.tar
       - name: Save
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: controller-image
           path: /tmp/controller-image.tar
@@ -76,7 +76,7 @@ jobs:
           tags: ghcr.io/appvia/terranetes-executor:ci
           outputs: type=docker,dest=/tmp/executor-image.tar
       - name: Save
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: executor-image
           path: /tmp/executor-image.tar


### PR DESCRIPTION
Bumping the version to v3 as node 12 actions are deprecated
