### PR TITLE
[BUGFIX] - Wrap log watcher Pod with error handling and retry logic

### DIFF
--- a/charts/terranetes-controller/values.yaml
+++ b/charts/terranetes-controller/values.yaml
@@ -35,7 +35,7 @@ controller:
     # image to use for infracost
     infracost: infracost/infracost:0.10.13
     # policy is image for policy
-    policy: bridgecrew/checkov:2.2.31
+    policy: bridgecrew/checkov:2.2.58
     # is the controller image
     controller: ghcr.io/appvia/terranetes-controller:v0.3.12
     # The terranetes image used when running jobs

--- a/images/Dockerfile.executor
+++ b/images/Dockerfile.executor
@@ -22,4 +22,7 @@ COPY --from=builder /go/src/github.com/appvia/terranetes-controller/bin/step /bi
 
 COPY images/assets/ssh_config /etc/ssh/ssh_config
 
+COPY images/assets/watch_logs.sh /watch_logs.sh
+RUN chmod +x /watch_logs.sh
+
 USER 1001

--- a/images/assets/watch_logs.sh
+++ b/images/assets/watch_logs.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Copyright 2022 Appvia Ltd <info@appvia.io>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+set -o errexit
+set -o pipefail
+${TRACE:+set -x}
+
+# Variables
+LOGFILE="/tmp/build.log"
+DELAY=5
+MAX_RETRIES=10
+LOGS_FETCHED=false
+FLAG_ENDPOINT=""
+FLAG_LOGFILE="${LOGFILE}"
+FLAG_DELAY=${DELAY}
+FLAG_MAX_RETRIES=${MAX_RETRIES}
+
+# Help instructions for this script.
+print_usage() {
+  printf "\nUSAGE: $0 [flags]
+
+Flags:
+  -e  The endpoint to poll and fetch container logs (default: none)
+  -f  The logfile to output build logs retrieved from the Terranetes Controller (default: $LOGFILE)
+  -d  Delay in seconds between each log retrieval attempt (default: $DELAY)
+  -r  Maximum log retrieval retries to attempt (default: $MAX_RETRIES)
+  -h  show this help\n"
+}
+
+# Check that all required arguments have been supplied
+check_required_arguments() {
+  echo "[info] Checking if required flags have been provided."
+  for var in "FLAG_ENDPOINT" "FLAG_LOGFILE" "FLAG_DELAY" "FLAG_MAX_RETRIES"; do
+    if [ -z "${!var}" ]; then
+      echo "Error: Variable ${var} has no value."
+      print_usage
+      exit 1
+    fi
+  done
+}
+
+stream_logs() {
+    i=1
+    while [[ ${i} -le ${FLAG_MAX_RETRIES} ]]; do
+        echo "[info] Waiting ${FLAG_DELAY} seconds for pod logs to be available (attempt ${i}/${FLAG_MAX_RETRIES}).."
+        sleep ${FLAG_DELAY}
+
+        if curl --no-buffer --silent ${FLAG_ENDPOINT} | tee ${FLAG_LOGFILE}; then
+            if [[ $(grep "failed to retrieve the logs" ${FLAG_LOGFILE}) ]]; then
+                echo "[info] Terranetes Controller was unable to retrieve logs, the Job Pod may not be available yet."
+                i=$((i+1))
+            else
+                LOGS_FETCHED=true
+                return
+            fi
+        else
+            echo "[warning] Terranetes Controller not reachable, unable to fetch logs."
+            i=$((i+1))
+        fi
+    done
+}
+
+# The main function
+main() {
+    check_required_arguments
+
+    stream_logs
+
+    if [[ ${LOGS_FETCHED} == false ]]; then
+        echo "[error] Unable to retrieve Job Pod logs after ${FLAG_MAX_RETRIES} attempts."
+        exit 1
+    fi
+
+    if [[ $(grep "level=error" ${FLAG_LOGFILE}) ]]; then
+        echo "[error] Job failure occurred, view the Terraform logs for more info."
+        exit 1
+    fi
+
+    if ! grep -qi "build.*complete" ${FLAG_LOGFILE}; then
+        echo "[error] An unexpected error occurred, view the Pod logs for more info."
+        exit 1
+    fi
+}
+
+# Parse arguments provided to the script and error if any are unexpected
+while getopts 'e:f:d:r:h' flag; do
+    case "${flag}" in
+        e) FLAG_ENDPOINT="${OPTARG}" ;;
+        f) FLAG_LOGFILE="${OPTARG}" ;;
+        d) FLAG_DELAY="${OPTARG}" ;;
+        r) FLAG_MAX_RETRIES="${OPTARG}" ;;
+        h) print_usage && exit 0 ;;
+        *) print_usage
+        exit 1 ;;
+    esac
+done
+
+# Run the main function
+main

--- a/pkg/controller/configuration/helper.go
+++ b/pkg/controller/configuration/helper.go
@@ -64,7 +64,7 @@ func GetTerraformImage(configuration *terraformv1alphav1.Configuration, image st
 
 // CreateWatcher is responsible for ensuring the logger is running in the application namespace
 func (c Controller) CreateWatcher(ctx context.Context, configuration *terraformv1alphav1.Configuration, stage string) error {
-	watcher := jobs.New(configuration, nil).NewJobWatch(c.ControllerNamespace, stage)
+	watcher := jobs.New(configuration, nil).NewJobWatch(c.ControllerNamespace, stage, c.ExecutorImage)
 
 	// @step: check if the logger has been created
 	found, err := kubernetes.GetIfExists(ctx, c.cc, watcher.DeepCopy())

--- a/pkg/controller/configuration/reconcile_test.go
+++ b/pkg/controller/configuration/reconcile_test.go
@@ -1083,7 +1083,8 @@ terraform {
 
 			container := list.Items[0].Spec.Template.Spec.Containers[0]
 			Expect(container.Name).To(Equal("watch"))
-			Expect(container.Command).To(Equal([]string{"sh"}))
+			Expect(container.Command).To(Equal([]string{"/watch_logs.sh"}))
+			Expect(container.Args).To(Equal([]string{"-e", "http://controller.default.svc.cluster.local/v1/builds/apps/bucket/logs?generation=0&name=bucket&namespace=apps&stage=plan&uid=1234-122-1234-1234"}))
 		})
 
 		It("should have added a approval annotation to the configuration", func() {
@@ -1395,7 +1396,8 @@ terraform {
 
 				container := list.Items[0].Spec.Template.Spec.Containers[0]
 				Expect(container.Name).To(Equal("watch"))
-				Expect(container.Command).To(Equal([]string{"sh"}))
+				Expect(container.Command).To(Equal([]string{"/watch_logs.sh"}))
+				Expect(container.Args).To(Equal([]string{"-e", "http://controller.default.svc.cluster.local/v1/builds/apps/bucket/logs?generation=0&name=bucket&namespace=apps&stage=plan&uid=1234-122-1234-1234"}))
 			})
 		})
 
@@ -2136,7 +2138,8 @@ terraform {
 
 				container := list.Items[0].Spec.Template.Spec.Containers[0]
 				Expect(container.Name).To(Equal("watch"))
-				Expect(container.Command).To(Equal([]string{"sh"}))
+				Expect(container.Command).To(Equal([]string{"/watch_logs.sh"}))
+				Expect(container.Args).To(Equal([]string{"-e", "http://controller.default.svc.cluster.local/v1/builds/apps/bucket/logs?generation=0&name=bucket&namespace=apps&stage=apply&uid=1234-122-1234-1234"}))
 			})
 
 			It("should ask us to requeue", func() {


### PR DESCRIPTION
**Desired behaviour:**
- Retry if the [Terranetes controller cannot be reached](https://github.com/appvia/terranetes-controller/pull/493/files#diff-daf24424c5712e22bd0c8e200b5496ef4167be92fd8d4a411d713b07e506785aR70)
- Retry if the Terranetes controller was [unable to retrieve logs from the executor pod](https://github.com/appvia/terranetes-controller/pull/493/files#diff-daf24424c5712e22bd0c8e200b5496ef4167be92fd8d4a411d713b07e506785aR63) (the one performing the tf plan, apply, checkov tests etc)
- Return a non-zero exit code and don't retry / restart the watcher pod if the log output shows a failure of some sort:
  - A [log error was detected](https://github.com/appvia/terranetes-controller/pull/493/files#diff-daf24424c5712e22bd0c8e200b5496ef4167be92fd8d4a411d713b07e506785aR87-R90)
  - The Terraform Executor had an [unexpected failure when streaming log output](https://github.com/appvia/terranetes-controller/pull/493/files#diff-daf24424c5712e22bd0c8e200b5496ef4167be92fd8d4a411d713b07e506785aR92-R95)