### PR TITLE
[BUGFIX] - Checkov Policies Zero Matches

### DIFF
--- a/pkg/cmd/tnctl/describe/assets/describe.yaml.tpl
+++ b/pkg/cmd/tnctl/describe/assets/describe.yaml.tpl
@@ -49,6 +49,7 @@ Secret:         None
 
 Checkov Security Policy:
 =======================
+{{- if .Policy.results }}
 Status:        Configuration has passed {{ .Policy.results.passed_checks | len }} and failed on {{ .Policy.results.failed_checks | len }} checks.
 {{ range $check := .Policy.results.failed_checks }}
 {{ printf "%-15s%s" $check.check_id "FAILED" }}
@@ -64,7 +65,9 @@ Status:        Configuration has passed {{ .Policy.results.passed_checks | len }
 └─ Guide:      {{ default "-" $check.guideline }}
 {{- end }}
 {{- end }}
-
+{{- else }}
+Status:        No matching security checks found, configuration passed.
+{{- end }}
 {{- if .Cost }}
 
 Predicted Costs:


### PR DESCRIPTION
When security policies produces zero matches on passes and fails the report was not matching the expected out.

- Adjusted the controller to permit a zero matching report
- Adjusted the tnctl describe to support as well
