### PR TITLE
added job-template flag

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -54,6 +54,7 @@ func main() {
 	flags := cmd.Flags()
 	flags.Bool("verbose", false, "Enable verbose logging")
 	flags.StringVar(&config.BackendTemplate, "backend-template", "", "Name of secret in the controller namespace containing a template for the terraform state")
+	flags.StringVar(&config.JobTemplate, "job-template", "", "Name of configmap in the controller namespace containing a template for the job")
 	flags.BoolVar(&config.EnableContextInjection, "enable-context-injection", false, "Indicates the controller should inject Configuration context into the terraform variables")
 	flags.BoolVar(&config.EnableTerraformVersions, "enable-terraform-versions", true, "Indicates the terraform version can be overridden by configurations")
 	flags.BoolVar(&config.EnableWatchers, "enable-watchers", true, "Indicates we create watcher jobs in the configuration namespaces")


### PR DESCRIPTION
When running with a custom [job template.](https://terranetes.appvia.io/terranetes-controller/admin/template/), the controller fails to start with error `[error] unknown flag: --job-template`

As far as I can see all code is in place except the flag is missing.