### PR TITLE
[FEATURE] - Kubernetes Backend Secret Labels

### DIFF
--- a/pkg/controller/configuration/reconcile_test.go
+++ b/pkg/controller/configuration/reconcile_test.go
@@ -965,6 +965,12 @@ terraform {
 	backend "kubernetes" {
 		in_cluster_config = true
 		namespace         = "default"
+		labels            = {
+			"terraform.appvia.io/configuration" = "bucket"
+			"terraform.appvia.io/configuration-uid" = "1234-122-1234-1234"
+			"terraform.appvia.io/generation" = "0"
+			"terraform.appvia.io/namespace" = "apps"
+		}
 		secret_suffix     = "1234-122-1234-1234"
 	}
 }


### PR DESCRIPTION
The kubernetes backend for terraform supports labels which can be useful for filtering out the state to Configuration. This PR adds those labels to the secret created by terraform.
