### PR TITLE
[FEATURE] - Kubernetes State Command

### DIFF
--- a/pkg/cmd/helper.go
+++ b/pkg/cmd/helper.go
@@ -20,15 +20,35 @@ package cmd
 import (
 	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 
+	"github.com/olekukonko/tablewriter"
 	"github.com/spf13/cobra"
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	terraformv1alphav1 "github.com/appvia/terranetes-controller/pkg/apis/terraform/v1alpha1"
 )
+
+// NewTableWriter returns a default table writer
+func NewTableWriter(out io.Writer) *tablewriter.Table {
+	tw := tablewriter.NewWriter(out)
+	tw.SetAutoWrapText(false)
+	tw.SetAutoFormatHeaders(true)
+	tw.SetHeaderAlignment(tablewriter.ALIGN_LEFT)
+	tw.SetAlignment(tablewriter.ALIGN_LEFT)
+	tw.SetCenterSeparator("")
+	tw.SetColumnSeparator("")
+	tw.SetRowSeparator("")
+	tw.SetHeaderLine(false)
+	tw.SetBorder(false)
+	tw.SetTablePadding("\t")
+	tw.SetNoWhiteSpace(true)
+
+	return tw
+}
 
 // AutoCompletionFunc is a function that returns a list of completions
 type AutoCompletionFunc func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective)

--- a/pkg/cmd/tnctl/search/search.go
+++ b/pkg/cmd/tnctl/search/search.go
@@ -69,7 +69,7 @@ registry, nothing is required, but for private repositories on Github your
 environment must already be setup to git clone the repository.
 `
 
-// Command returns the cobra command for the "build" sub-command.
+// Command returns the cobra command
 type Command struct {
 	cmd.Factory
 	// EnableDefaults indicates if any defaults with values from the terraform module are included

--- a/pkg/cmd/tnctl/state/clean.go
+++ b/pkg/cmd/tnctl/state/clean.go
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2022  Appvia Ltd <info@appvia.io>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package state
+
+import (
+	"bufio"
+	"context"
+	"strings"
+	"time"
+
+	"github.com/appvia/terranetes-controller/pkg/cmd"
+	"github.com/spf13/cobra"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/duration"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	terraformv1alphav1 "github.com/appvia/terranetes-controller/pkg/apis/terraform/v1alpha1"
+)
+
+// CleanCommand is the options for the clean command
+type CleanCommand struct {
+	cmd.Factory
+	// ControllerNamespace is the namespace the controller is running in
+	ControllerNamespace string
+	// Force will force the deletion of the state
+	Force bool
+}
+
+var longCleanHelp = `
+The clean command will clean any orphaned state, cost, config or policy secrets.
+These are kubernetes secrets which are not associated with a configuration.
+
+# Clean all orphaned secrets (you will be prompted to confirm)
+$ tnctl state clean
+`
+
+// NewCleanCommand creates and returns a new clean command
+func NewCleanCommand(factory cmd.Factory) *cobra.Command {
+	o := &CleanCommand{Factory: factory}
+
+	c := &cobra.Command{
+		Use:   "clean [OPTIONS]",
+		Long:  longCleanHelp,
+		Short: "Cleans any orphaned state, cost, config or policy secrets",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return o.Run(cmd.Context())
+		},
+	}
+
+	flags := c.Flags()
+	flags.StringVar(&o.ControllerNamespace, "controller-namespace", "terraform-system", "The namespace the controller is running in")
+	flags.BoolVar(&o.Force, "force", false, "Force the deletion of the secrets")
+
+	return c
+}
+
+// Run implements the command
+func (o *CleanCommand) Run(ctx context.Context) error {
+	// @step: retrieve a kubernetes client
+	cc, err := o.GetClient()
+	if err != nil {
+		return err
+	}
+
+	// @step: retrieve the list of configurations
+	list := &terraformv1alphav1.ConfigurationList{}
+	if err := cc.List(ctx, list); err != nil {
+		return err
+	}
+
+	// @step: retrieve all the secrets within the controller namespace
+	secrets := &v1.SecretList{}
+	if err := cc.List(ctx, secrets, client.InNamespace(o.ControllerNamespace)); err != nil {
+		return err
+	}
+
+	// findMatchingConfiguration return true if the uuid is found
+	findMatchingConfiguration := func(uuid string, list *terraformv1alphav1.ConfigurationList) bool {
+		for _, x := range list.Items {
+			if string(x.GetUID()) == uuid {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	// @step: iterate the secrets and remove any orphaned secrets
+	var data [][]string
+	for _, secret := range secrets.Items {
+		if !ConfigurationSecretRegex.MatchString(secret.Name) {
+			continue
+		}
+		uuid := ConfigurationSecretRegex.FindStringSubmatch(secret.Name)[2]
+
+		if !findMatchingConfiguration(uuid, list) {
+			row := []string{secret.Name}
+
+			if secret.GetLabels()[terraformv1alphav1.ConfigurationNameLabel] != "" {
+				row = append(row, secret.GetLabels()[terraformv1alphav1.ConfigurationNameLabel])
+			} else {
+				row = append(row, "Unknown")
+			}
+			if secret.GetLabels()[terraformv1alphav1.ConfigurationNamespaceLabel] != "" {
+				row = append(row, secret.GetLabels()[terraformv1alphav1.ConfigurationNamespaceLabel])
+			} else {
+				row = append(row, "Unknown")
+			}
+			row = append(row, duration.HumanDuration(time.Since(secret.GetCreationTimestamp().Time)))
+			data = append(data, row)
+		}
+	}
+
+	if len(data) == 0 {
+		o.Println("\nNo orphaned secrets found")
+
+		return nil
+	}
+
+	tw := cmd.NewTableWriter(o.Stdout())
+	tw.SetHeader([]string{"Name", "Configuration", "Namespace", "Age"})
+	tw.AppendBulk(data)
+	tw.Render()
+
+	if !o.Force {
+		o.Printf("\nYou have %d secrets orphaned which can be removed, do you wish to delete? (y/n) ", len(data))
+		choice, err := bufio.NewReader(o.GetStreams().In).ReadString('\n')
+		if err != nil {
+			return err
+		}
+		if strings.ToLower(strings.TrimSpace(choice)) != "y" {
+			o.Println("Skipped deleting orphaned secrets")
+
+			return nil
+		}
+	}
+
+	for _, row := range data {
+		name := row[0]
+
+		secret := &v1.Secret{}
+		secret.Namespace = o.ControllerNamespace
+		secret.Name = name
+
+		if err := cc.Delete(ctx, secret); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/pkg/cmd/tnctl/state/helper.go
+++ b/pkg/cmd/tnctl/state/helper.go
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2022  Appvia Ltd <info@appvia.io>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package state
+
+import (
+	"regexp"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+// SecretPrefixes is a list of secret prefixes the controller uses
+var SecretPrefixes = []string{
+	"tfstate-default-",
+	"config-",
+	"policy-",
+	"cost-",
+}
+
+// ConfigurationSecretRegex is the regex for a configuration secret
+var ConfigurationSecretRegex = regexp.MustCompile(
+	`^(tfstate-default|config|policy|cost)-(([a-z0-9]){8}-([a-z0-9]){4}-([a-z0-9]){4}-([a-z0-9]){4}-([a-z0-9]){12})$`,
+)
+
+// findSecretByPrefix is used to find a secret by prefix and uuid
+func findSecretByPrefix(prefix, id string, secrets *v1.SecretList) (string, bool) {
+	for _, x := range secrets.Items {
+		switch {
+		case !strings.HasPrefix(x.Name, prefix):
+			continue
+		case !strings.HasSuffix(x.Name, id):
+			continue
+		}
+
+		return x.Name, true
+	}
+
+	return "", false
+}

--- a/pkg/cmd/tnctl/state/list.go
+++ b/pkg/cmd/tnctl/state/list.go
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2022  Appvia Ltd <info@appvia.io>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package state
+
+import (
+	"context"
+	"time"
+
+	"github.com/spf13/cobra"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/duration"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	terraformv1alphav1 "github.com/appvia/terranetes-controller/pkg/apis/terraform/v1alpha1"
+	"github.com/appvia/terranetes-controller/pkg/cmd"
+)
+
+// ListCommand is the options for the list command
+type ListCommand struct {
+	cmd.Factory
+	// ControllerNamespace is the namespace the controller is running in
+	ControllerNamespace string
+	// Namespace is the namespace to list the configurations, defaults to all
+	Namespace string
+}
+
+// NewListCommand creates and returns a new list command
+func NewListCommand(factory cmd.Factory) *cobra.Command {
+	o := &ListCommand{Factory: factory}
+
+	c := &cobra.Command{
+		Use:     "list [OPTIONS]",
+		Aliases: []string{"ls"},
+		Short:   "Listing all the configurations in the cluster and the current state",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return o.Run(cmd.Context())
+		},
+	}
+
+	flags := c.Flags()
+	flags.StringVar(&o.ControllerNamespace, "controller-namespace", "terraform-system", "The namespace the controller is running in")
+	flags.StringVar(&o.Namespace, "namespace", "", "The namespace to list the configurations, defaults to all")
+
+	return c
+}
+
+// Run implements the command
+func (o *ListCommand) Run(ctx context.Context) error {
+	// @step: retrieve a kubernetes client
+	cc, err := o.GetClient()
+	if err != nil {
+		return err
+	}
+
+	// @step: retrieve the list of configurations
+	list := &terraformv1alphav1.ConfigurationList{}
+	if err := cc.List(ctx, list, client.InNamespace(o.Namespace)); err != nil {
+		return err
+	}
+	if len(list.Items) == 0 {
+		o.Println("No configurations found")
+
+		return nil
+	}
+
+	// @step: retrieve all the secrets within the controller namespace
+	secrets := &v1.SecretList{}
+	if err := cc.List(ctx, secrets, client.InNamespace(o.ControllerNamespace)); err != nil {
+		return err
+	}
+
+	// @step: lets build the rows
+	var data [][]string
+	for _, x := range list.Items {
+		row := []string{x.Name}
+		for _, prefix := range SecretPrefixes {
+			if name, found := findSecretByPrefix(prefix, string(x.GetUID()), secrets); found {
+				row = append(row, name)
+			} else {
+				row = append(row, "None")
+			}
+		}
+		row = append(row, duration.HumanDuration(time.Since(x.GetCreationTimestamp().Time)))
+
+		data = append(data, row)
+	}
+
+	tw := cmd.NewTableWriter(o.Stdout())
+	tw.SetHeader([]string{
+		"Configuration",
+		"State",
+		"Config",
+		"Policy",
+		"Cost",
+		"Age",
+	})
+	tw.AppendBulk(data)
+	tw.Render()
+
+	return nil
+}

--- a/pkg/cmd/tnctl/state/list_test.go
+++ b/pkg/cmd/tnctl/state/list_test.go
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2022  Appvia Ltd <info@appvia.io>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package state
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/appvia/terranetes-controller/pkg/cmd"
+	"github.com/appvia/terranetes-controller/pkg/schema"
+	"github.com/appvia/terranetes-controller/test/fixtures"
+)
+
+var _ = Describe("Listing the state", func() {
+	logrus.SetOutput(ioutil.Discard)
+	testUID := "4845842d-f29b-4d12-8f6a-b73c7bf82836"
+
+	var cc client.Client
+	var kc *k8sfake.Clientset
+	var factory cmd.Factory
+	var streams genericclioptions.IOStreams
+	var stdout *bytes.Buffer
+	var command *cobra.Command
+	var err error
+
+	BeforeEach(func() {
+		cc = fake.NewFakeClientWithScheme(schema.GetScheme())
+		kc = k8sfake.NewSimpleClientset()
+
+		streams, _, stdout, _ = genericclioptions.NewTestIOStreams()
+		factory = &fixtures.Factory{
+			RuntimeClient: cc,
+			KubeClient:    kc,
+			Streams:       streams,
+		}
+		command = NewCommand(factory)
+	})
+
+	When("no configurations exist", func() {
+		BeforeEach(func() {
+			os.Args = []string{"state", "list"}
+			err = command.Execute()
+		})
+
+		It("should not error", func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should indicate no configurations found", func() {
+			Expect(stdout.String()).To(Equal("No configurations found"))
+		})
+	})
+
+	When("configurations exist", func() {
+
+		BeforeEach(func() {
+			cfg := fixtures.NewValidBucketConfiguration("default", "test")
+			cfg.UID = types.UID(testUID)
+			cc.Create(context.Background(), cfg)
+			os.Args = []string{"state", "list"}
+			err = command.Execute()
+		})
+
+		It("should not error", func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should list the configurations", func() {
+			Expect(stdout.String()).To(Equal("CONFIGURATION\tSTATE\tCONFIG\tPOLICY\tCOST\tAGE  \ntest         \tNone \tNone  \tNone  \tNone\t292y\t\n"))
+		})
+	})
+
+	When("we have configuration secrets present", func() {
+		BeforeEach(func() {
+			cfg := fixtures.NewValidBucketConfiguration("default", "test")
+			cfg.UID = types.UID(testUID)
+			cc.Create(context.Background(), cfg)
+
+			for _, prefix := range SecretPrefixes {
+				name := fmt.Sprintf("%s%v", prefix, testUID)
+				secret := &v1.Secret{}
+				secret.Name = name
+				secret.Namespace = "terraform-system"
+				Expect(cc.Create(context.Background(), secret)).ToNot(HaveOccurred())
+			}
+			os.Args = []string{"state", "list"}
+			err = command.Execute()
+		})
+
+		It("should not error", func() {
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should list the configurations", func() {
+			Expect(stdout.String()).To(ContainSubstring("tfstate-default-4845842d-f29b-4d12-8f6a-b73c7bf82836"))
+		})
+	})
+})

--- a/pkg/cmd/tnctl/state/state.go
+++ b/pkg/cmd/tnctl/state/state.go
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2022  Appvia Ltd <info@appvia.io>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package state
+
+import (
+	"github.com/appvia/terranetes-controller/pkg/cmd"
+	"github.com/spf13/cobra"
+)
+
+// Command returns the cobra command
+type Command struct {
+	cmd.Factory
+}
+
+var longDesc = `
+When using the kubernetes backend to store the terraform state, this
+command provides the ability to list, clean and match up state secrets
+against the Configuration CRD which are using them.
+`
+
+// NewCommand returns a new instance of the command
+func NewCommand(factory cmd.Factory) *cobra.Command {
+	c := &cobra.Command{
+		Use:   "state [COMMAND]",
+		Long:  longDesc,
+		Short: "Used to manage the Terraform Configuration state secrets",
+	}
+
+	c.AddCommand(
+		NewListCommand(factory),
+		NewCleanCommand(factory),
+	)
+
+	return c
+}

--- a/pkg/cmd/tnctl/state/suite_test.go
+++ b/pkg/cmd/tnctl/state/suite_test.go
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2022  Appvia Ltd <info@appvia.io>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package state
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestReconcile(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Running Test Suite")
+}

--- a/pkg/cmd/tnctl/tnctl.go
+++ b/pkg/cmd/tnctl/tnctl.go
@@ -37,6 +37,7 @@ import (
 	"github.com/appvia/terranetes-controller/pkg/cmd/tnctl/kubectl"
 	"github.com/appvia/terranetes-controller/pkg/cmd/tnctl/logs"
 	"github.com/appvia/terranetes-controller/pkg/cmd/tnctl/search"
+	"github.com/appvia/terranetes-controller/pkg/cmd/tnctl/state"
 	"github.com/appvia/terranetes-controller/pkg/cmd/tnctl/workflow"
 	"github.com/appvia/terranetes-controller/pkg/version"
 )
@@ -80,6 +81,7 @@ func New(factory cmd.Factory) *cobra.Command {
 		workflow.NewCommand(factory),
 		describe.NewCommand(factory),
 		generate.NewCommand(factory),
+		state.NewCommand(factory),
 		logs.NewCommand(factory),
 	)
 


### PR DESCRIPTION
This PR adds the tnctl state list|clean commands which can be used to show the matching configuration and secrets. The
clean command provide spring cleaning, removing any orphaned secrets
