### PR TITLE
[BUGFIX] - Fixing Ready Condition Transition

### DIFF
--- a/pkg/controller/configuration/reconcile_test.go
+++ b/pkg/controller/configuration/reconcile_test.go
@@ -2167,6 +2167,15 @@ terraform {
 				Expect(cond.Message).To(Equal("Waiting for terraform apply annotation to be set to true"))
 			})
 
+			It("should indicate the ready condition is false", func() {
+				Expect(cc.Get(context.TODO(), configuration.GetNamespacedName(), configuration)).ToNot(HaveOccurred())
+
+				cond := configuration.Status.GetCondition(corev1alphav1.ConditionReady)
+				Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+				Expect(cond.Reason).To(Equal(corev1alphav1.ReasonInProgress))
+				Expect(cond.Message).To(Equal("Waiting for changes to be approved"))
+			})
+
 			It("should have raised a kubernetes event", func() {
 				Expect(recorder.Events).To(HaveLen(1))
 				Expect(recorder.Events[0]).To(Equal("(apps/bucket) Warning Action Required: Waiting for terraform apply annotation to be set to true"))

--- a/pkg/controller/ensure.go
+++ b/pkg/controller/ensure.go
@@ -56,7 +56,7 @@ func RequeueAfter(d time.Duration) EnsureFunc {
 
 // Run is a generic handler for running the ensure methods
 func (e *EnsureRunner) Run(ctx context.Context, cc client.Client, resource Object, ensures []EnsureFunc) (result reconcile.Result, rerr error) {
-	original := resource.DeepCopyObject()
+	original := resource.DeepCopyObject().(client.Object)
 	status := resource.GetCommonStatus()
 
 	status.LastReconcile = &corev1alphav1.LastReconcileStatus{
@@ -68,7 +68,7 @@ func (e *EnsureRunner) Run(ctx context.Context, cc client.Client, resource Objec
 	// see a drift. And updating the status of the resource overall
 	defer func() {
 		// @step: we need to update the status of the resource
-		if err := cc.Status().Patch(ctx, resource, client.MergeFrom(original.(client.Object))); err != nil {
+		if err := cc.Status().Patch(ctx, resource, client.MergeFrom(original)); err != nil {
 			if err := client.IgnoreNotFound(err); err != nil {
 				log.WithError(err).Error("failed to update the status of resource")
 


### PR DESCRIPTION
The ready state needed to be reset in between the plan and the apply. The bug allowed
for error conditions to linger on the ready condition which were no longer valid i.e https://github.com/appvia/terranetes-controller/issues/525
