### PR TITLE
[BUILD] - Change Module Security Restriction Message

### DIFF
--- a/pkg/handlers/configurations/validation.go
+++ b/pkg/handlers/configurations/validation.go
@@ -217,5 +217,5 @@ func validateModuleConstriants(
 		}
 	}
 
-	return fmt.Errorf("configuration has been denied by policy")
+	return fmt.Errorf("spec.module: source has been denied by module policy, contact an administrator")
 }

--- a/pkg/handlers/configurations/validation_test.go
+++ b/pkg/handlers/configurations/validation_test.go
@@ -171,7 +171,7 @@ var _ = Describe("Configuration Validation", func() {
 			It("should deny the configuration of the module", func() {
 				err := v.ValidateCreate(ctx, fixtures.NewValidBucketConfiguration(namespace, "test"))
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("configuration has been denied by policy"))
+				Expect(err.Error()).To(Equal("spec.module: source has been denied by module policy, contact an administrator"))
 			})
 		})
 
@@ -223,7 +223,7 @@ var _ = Describe("Configuration Validation", func() {
 
 				err := v.ValidateCreate(ctx, fixtures.NewValidBucketConfiguration(namespace, "test"))
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(Equal("configuration has been denied by policy"))
+				Expect(err.Error()).To(Equal("spec.module: source has been denied by module policy, contact an administrator"))
 			})
 
 			It("should be allowed by the second policy", func() {

--- a/test/e2e/integration/constraints/modules.bats
+++ b/test/e2e/integration/constraints/modules.bats
@@ -61,8 +61,9 @@ spec:
     namespace: terraform-system
     name: fake
 EOF
+  expected="spec.module: source has been denied by module policy, contact an administrator"
 
-  runit "kubectl -n ${APP_NAMESPACE} apply -f ${BATS_TMPDIR}/resource.yaml 2>&1" "grep 'configuration has been denied by policy'"
+  runit "kubectl -n ${APP_NAMESPACE} apply -f ${BATS_TMPDIR}/resource.yaml 2>&1" "grep '${expected}'"
   [[ "$status" -eq 0 ]]
 }
 


### PR DESCRIPTION
The current message which is thrown when a Configuration violates a module security policy can be confusing. Trying to make the source of the error more clear.
