### PR TITLE
[BUGFIX] - Disable Infracosts Update Check

### DIFF
--- a/pkg/assets/job.yaml.tpl
+++ b/pkg/assets/job.yaml.tpl
@@ -235,6 +235,8 @@ spec:
         env:
           - name: COST_REPORT_NAME
             value: {{ .Secrets.InfracostsReport }}
+          - name: INFRACOST_SKIP_UPDATE_CHECK
+            value: "true"
           - name: KUBE_NAMESPACE
             valueFrom:
               fieldRef:


### PR DESCRIPTION
Adding the environment variable to disable checking for updates in the CLI breakdown of infracosts
