### PR TITLE
[E2E] - Workflow Run Name Typo

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,6 +1,6 @@
 ---
 name: E2E
-run-name: Running E2E for Deploy ${{ inputs.cloud }}
+run-name: Running E2E for ${{ inputs.cloud }}
 
 on:
   workflow_call:


### PR DESCRIPTION
Fixing the extra word in the run name of the workfow
