### PR TITLE
[FEATURE] - Adding Default Secrets into Policy

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,6 +1,6 @@
 ---
 name: E2E
-run-name: Running E2E for ${{ inputs.cloud }}
+run-name: Running E2E for ${{ inputs.cloud }} (${{ github.ref_name }})
 
 on:
   workflow_call:

--- a/charts/terranetes-controller/templates/policies.yaml
+++ b/charts/terranetes-controller/templates/policies.yaml
@@ -1,6 +1,5 @@
 {{- range $i, $o := .Values.policies }}
 {{- $name := $o.name | required (printf ".Values.policies[%d].name is required." $i) -}}
-{{- $constraint := $o.constraint | required (printf ".Values.policies[%d].constraint is required." $i) -}}
 ---
 apiVersion: terraform.appvia.io/v1alpha1
 kind: Policy
@@ -15,5 +14,10 @@ metadata:
     {{ $k }}: "{{ $v }}"
     {{- end }}
 spec:
-  constraints: {{ $constraint | toYaml | nindent 4 }}
+  {{- if $o.constraint }}
+  constraints: {{ $o.constraint | toYaml | nindent 4 }}
+  {{- end }}
+  {{- if $o.defaults }}
+  defaults: {{ $o.defaults | toYaml | nindent 4 }}
+  {{- end }}
 {{ end }}

--- a/charts/terranetes-controller/values.yaml
+++ b/charts/terranetes-controller/values.yaml
@@ -145,6 +145,7 @@ policies:
 #    constraint:
 #      modules:
 #        allowed: []
+#    defaults: []
 resources: {}
 # These resources are applied to the controller
 # limits:

--- a/examples/policy.yaml
+++ b/examples/policy.yaml
@@ -34,6 +34,24 @@ spec:
 apiVersion: terraform.appvia.io/v1alpha1
 kind: Policy
 metadata:
+  name: default-authentication
+spec:
+  defaults:
+    - selector:
+        namespace:
+          matchExpressions:
+            - key: kubernetes.io/metadata.name
+              operator: Exists
+        # You can also filter by modules
+        # modules: []
+      secrets:
+        # the secret must be located in the same namespace as the
+        # controller
+        - auth_token
+---
+apiVersion: terraform.appvia.io/v1alpha1
+kind: Policy
+metadata:
   name: checkov
 spec:
   constraints:

--- a/pkg/apis/terraform/v1alpha1/policy_types.go
+++ b/pkg/apis/terraform/v1alpha1/policy_types.go
@@ -96,10 +96,13 @@ type DefaultVariables struct {
 	// Selector is used to determine which configurations the variables should be injected into
 	// +kubebuilder:validation:Required
 	Selector DefaultVariablesSelector `json:"selector"`
+	// Secrets is a collection of secrets which are used to inject variables into the configuration
+	// +kubebuilder:validation:Optional
+	Secrets []string `json:"secrets,omitempty"`
 	// Variables is a collection of variables to inject into the configuration
-	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Optional
 	// +kubebuilder:pruning:PreserveUnknownFields
-	Variables runtime.RawExtension `json:"variables"`
+	Variables runtime.RawExtension `json:"variables,omitempty"`
 }
 
 // PolicySpec defines the desired state of a provider

--- a/pkg/assets/job.yaml.tpl
+++ b/pkg/assets/job.yaml.tpl
@@ -76,10 +76,15 @@ spec:
             - --command=/bin/cp /run/config/* /data
             - --command=/bin/cp /bin/step /run/bin/step
             - --command=/bin/source --dest=/data --source={{ .Configuration.Module }}
-          {{- if .Secrets.Config }}
           envFrom:
+          {{- if .Secrets.Config }}
             - secretRef:
                 name: {{ .Secrets.Config }}
+                optional: false
+          {{- end }}
+          {{- range .Secrets.AdditionalSecrets }}
+            - secretRef:
+                name: {{ . }}
                 optional: false
           {{- end }}
           volumeMounts:
@@ -98,6 +103,12 @@ spec:
             - /bin/terraform
           args:
             - init
+          envFrom:
+          {{- range .Secrets.AdditionalSecrets }}
+            - secretRef:
+                name: {{ . }}
+                optional: false
+          {{- end }}
           securityContext:
             capabilities:
               drop: [ALL]
@@ -115,8 +126,8 @@ spec:
           args:
             - --comment=Retrieve policy source
             - --command=/bin/source --dest=/run/checkov --source={{ .Policy.Source.URL }}
-          {{- if and (.Policy.Source.SecretRef) (.Policy.Source.SecretRef.Name) }}
           envFrom:
+          {{- if and (.Policy.Source.SecretRef) (.Policy.Source.SecretRef.Name) }}
             - secretRef
                 name: {{ .Policy.Source.SecretRef.Name }}
           {{- end }}
@@ -139,8 +150,8 @@ spec:
             - --comment=Retrieve external source for {{ .Name }}
             - --command=/bin/mkdir -p /run/policy
             - --command=/bin/source --dest=/run/policy/{{ .Name }} --source={{ .URL }}
-          {{- if and (.SecretRef) (.SecretRef.Name) }}
           envFrom:
+          {{- if and (.SecretRef) (.SecretRef.Name) }}
             - secretRef:
                 name: {{ .SecretRef.Name }}
           {{- end }}
@@ -200,6 +211,11 @@ spec:
           - secretRef:
               name: {{ . }}
               optional: true
+        {{- end }}
+        {{- range .Secrets.AdditionalSecrets }}
+          - secretRef:
+              name: {{ . }}
+              optional: false
         {{- end }}
         resources:
           limits:

--- a/pkg/controller/configuration/reconcile.go
+++ b/pkg/controller/configuration/reconcile.go
@@ -49,6 +49,9 @@ type state struct {
 	jobs *batchv1.JobList
 	// jobTemplate is the template to use when rendering the job
 	jobTemplate []byte
+	// additionalJobSecrets is a collection of additional secrets to job - these secrets
+	// must reside in the same namespace as the controller
+	additionalJobSecrets []string
 	// valueFrom is a map of keys to values
 	valueFrom map[string]string
 	// tfstate is the secret containing the terraform state
@@ -89,6 +92,7 @@ func (c *Controller) Reconcile(ctx context.Context, request reconcile.Request) (
 				c.ensureCapturedState(configuration, state),
 				c.ensureCustomBackendTemplate(configuration, state),
 				c.ensureProviderReady(configuration, state),
+				c.ensurePolicyDefaultsExist(configuration, state),
 				c.ensureAuthenticationSecret(configuration, state),
 				c.ensureCustomJobTemplate(configuration, state),
 				c.ensureTerraformDestroy(configuration, state),
@@ -120,6 +124,7 @@ func (c *Controller) Reconcile(ctx context.Context, request reconcile.Request) (
 			c.ensureAuthenticationSecret(configuration, state),
 			c.ensureCustomJobTemplate(configuration, state),
 			c.ensureProviderReady(configuration, state),
+			c.ensurePolicyDefaultsExist(configuration, state),
 			c.ensureJobConfigurationSecret(configuration, state),
 			c.ensureTerraformPlan(configuration, state),
 			c.ensureCostStatus(configuration),

--- a/pkg/handlers/policies/validation_test.go
+++ b/pkg/handlers/policies/validation_test.go
@@ -231,6 +231,32 @@ var _ = Describe("Policy Validation", func() {
 
 })
 
+var _ = Describe("Defaults Validation", func() {
+	var cc client.Client
+	var policy *terraformv1alpha1.Policy
+	var err error
+
+	BeforeEach(func() {
+		cc = fake.NewClientBuilder().WithScheme(schema.GetScheme()).WithRuntimeObjects(fixtures.NewNamespace("default")).Build()
+		policy = fixtures.NewPolicy("test")
+	})
+
+	When("checking the default values", func() {
+		Context("and neither secrets or variables have been defined", func() {
+			BeforeEach(func() {
+				policy.Spec.Defaults = []terraformv1alpha1.DefaultVariables{{}}
+
+				err = (&validator{cc: cc}).ValidateCreate(context.TODO(), policy)
+			})
+
+			It("should return an error", func() {
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("spec.defaults[0]: must specify at least one variable or secret"))
+			})
+		})
+	})
+})
+
 var _ = Describe("Policy Delete Validation", func() {
 	var configurations []*terraformv1alpha1.Configuration
 	var policy *terraformv1alpha1.Policy

--- a/pkg/utils/jobs/jobs.go
+++ b/pkg/utils/jobs/jobs.go
@@ -42,6 +42,8 @@ const TerraformContainerName = "terraform"
 
 // Options is the configuration for the render
 type Options struct {
+	// AdditionalJobSecret is a collection of secrets which should be mounted into the job.
+	AdditionalJobSecrets []string
 	// AdditionalLabels are additional labels added to the job
 	AdditionalLabels map[string]string
 	// EnableInfraCosts is the flag to enable cost analysis
@@ -225,11 +227,12 @@ func (r *Render) createTerraformFromTemplate(options Options, stage string) (*ba
 			"Policy":     options.PolicyImage,
 		},
 		"Secrets": map[string]interface{}{
-			"Config":           r.configuration.GetTerraformConfigSecretName(),
-			"Infracosts":       options.InfracostsSecret,
-			"InfracostsReport": r.configuration.GetTerraformCostSecretName(),
-			"PolicyReport":     r.configuration.GetTerraformPolicySecretName(),
-			"TerraformState":   r.configuration.GetTerraformStateSecretName(),
+			"AdditionalSecrets": options.AdditionalJobSecrets,
+			"Config":            r.configuration.GetTerraformConfigSecretName(),
+			"Infracosts":        options.InfracostsSecret,
+			"InfracostsReport":  r.configuration.GetTerraformCostSecretName(),
+			"PolicyReport":      r.configuration.GetTerraformPolicySecretName(),
+			"TerraformState":    r.configuration.GetTerraformStateSecretName(),
 		},
 	}
 


### PR DESCRIPTION
At present we only allow for injecting defaults into a configuration - it would be nice however to inject secret based on a selector as well. For example the ability to support the platform team managing the deployment keys for private repositories. 

Lets take the following example - 
* The platform have a number of private repositories which need authentication to consume. 
* They don't want the developers to care about the authentication, it should be transparent to them.
* They have created a kubernetes secret in the controller namespace container a deployment key
* They want the x number of modules to use the ssh-key to clone by default

```yaml
---
apiVersion: terraform.appvia.io/v1alpha1
kind: Policy
metadata:
  name: environment-defaults
spec:
  defaults:
    - selector:
        namespace:
          matchExpressions:
            - key: kubernetes.io/metadata.name
              operator: Exists
        modules:
          - github.com/appvia/terraform-aws-rds
          - github.com/appvia/terraform-aws-private-repo
      secrets: 
        - deployment_key
```

In this case

* All configurations using the above modules references in all namespaces will incorporate the `deployment_key` secret and have the ability clone the repository.