### PR TITLE
[FEATURE] - Default Providers

### DIFF
--- a/pkg/apis/terraform/v1alpha1/provider_types.go
+++ b/pkg/apis/terraform/v1alpha1/provider_types.go
@@ -44,6 +44,11 @@ var ProviderGVK = schema.GroupVersionKind{
 	Kind:    ProviderKind,
 }
 
+var (
+	// DefaultProviderAnnotation indicates the default provider for all unset configurations
+	DefaultProviderAnnotation = "terranetes.appvia.io/default-provider"
+)
+
 // ProviderType is the type of cloud
 type ProviderType string
 

--- a/pkg/handlers/configurations/mutation_test.go
+++ b/pkg/handlers/configurations/mutation_test.go
@@ -26,6 +26,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	terraformv1alpha1 "github.com/appvia/terranetes-controller/pkg/apis/terraform/v1alpha1"
@@ -39,260 +40,347 @@ func TestReconcile(t *testing.T) {
 }
 
 var _ = Describe("Configuration Mutation", func() {
-	var policies *terraformv1alpha1.PolicyList
-	var m *mutator
+
+	var handler *mutator
 	var before, after *terraformv1alpha1.Configuration
+	var cc client.Client
 	var err error
 
-	ns := &v1.Namespace{}
-	ns.Name = "test"
-	ns.Labels = map[string]string{"app": "test"}
-
-	JustBeforeEach(func() {
-		after = before.DeepCopy()
-		b := fake.NewClientBuilder().
-			WithRuntimeObjects(ns.DeepCopy(), fixtures.NewNamespace("default")).
-			WithScheme(schema.GetScheme())
-
-		if policies != nil {
-			for _, x := range policies.Items {
-				b = b.WithRuntimeObjects(&x)
-			}
-		}
-		m = &mutator{cc: b.Build()}
-		err = m.Default(context.Background(), after)
-	})
-
-	Context("we have not policies", func() {
+	When("creating a configuration", func() {
 		BeforeEach(func() {
-			policies = nil
-			before = fixtures.NewValidBucketConfiguration("default", "test")
+			ns := fixtures.NewNamespace("app")
+			ns.Labels = map[string]string{"app": "test"}
+			cc = fake.NewClientBuilder().WithRuntimeObjects(ns).WithScheme(schema.GetScheme()).Build()
+			handler = &mutator{cc: cc}
+			before = fixtures.NewValidBucketConfiguration("app", "test")
+			after = before.DeepCopy()
 		})
 
-		It("should remain unchanged", func() {
-			Expect(before).To(Equal(after))
-			Expect(err).ToNot(HaveOccurred())
-		})
-	})
+		Context("and we have no policies", func() {
+			BeforeEach(func() {
+				err = handler.Default(context.Background(), after)
+			})
 
-	Context("we have policies but zero matches", func() {
-		BeforeEach(func() {
-			before = fixtures.NewValidBucketConfiguration("default", "test")
-			policies = &terraformv1alpha1.PolicyList{}
-			policy := fixtures.NewPolicy("test")
-			policy.Spec.Defaults = []terraformv1alpha1.DefaultVariables{
-				{
-					Selector: terraformv1alpha1.DefaultVariablesSelector{
-						Namespace: &metav1.LabelSelector{
-							MatchLabels: map[string]string{"app": "no_match"},
+			It("should not throw an error", func() {
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should remain unchanged", func() {
+				Expect(before).To(Equal(after))
+				Expect(err).ToNot(HaveOccurred())
+			})
+		})
+
+		Context("and we have zero matching policies", func() {
+			BeforeEach(func() {
+				policy := fixtures.NewPolicy("mutate")
+				policy.Spec.Defaults = []terraformv1alpha1.DefaultVariables{
+					{
+						Selector: terraformv1alpha1.DefaultVariablesSelector{
+							Namespace: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"app": "no_match"},
+							},
+						},
+						Variables: runtime.RawExtension{
+							Raw: []byte(`{"foo": "bar"}`),
 						},
 					},
-					Variables: runtime.RawExtension{
-						Raw: []byte(`{"foo": "bar"}`),
-					},
-				},
-			}
-			policies.Items = append(policies.Items, *policy)
+				}
+				Expect(cc.Create(context.Background(), policy)).To(Succeed())
+
+				err = handler.Default(context.Background(), after)
+			})
+
+			It("should not throw an error", func() {
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should remain unchanged", func() {
+				Expect(before).To(Equal(after))
+				Expect(err).ToNot(HaveOccurred())
+			})
 		})
 
-		It("should remain unchanged", func() {
-			Expect(before).To(Equal(after))
-			Expect(err).ToNot(HaveOccurred())
-		})
-	})
-
-	Context("we have a match on the namespace selector", func() {
-		BeforeEach(func() {
-			before = fixtures.NewValidBucketConfiguration("test", "test")
-			before.Spec.Variables = &runtime.RawExtension{}
-
-			policies = &terraformv1alpha1.PolicyList{}
-			policy := fixtures.NewPolicy("test")
-			policy.Spec.Defaults = []terraformv1alpha1.DefaultVariables{
-				{
-					Selector: terraformv1alpha1.DefaultVariablesSelector{
-						Namespace: &metav1.LabelSelector{
-							MatchLabels: map[string]string{"app": "test"},
+		Context("and we have a matching namespace selector", func() {
+			BeforeEach(func() {
+				policy := fixtures.NewPolicy("mutate")
+				policy.Spec.Defaults = []terraformv1alpha1.DefaultVariables{
+					{
+						Selector: terraformv1alpha1.DefaultVariablesSelector{
+							Namespace: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"app": "test"},
+							},
+						},
+						Variables: runtime.RawExtension{
+							Raw: []byte(`{"is": "changed"}`),
 						},
 					},
-					Variables: runtime.RawExtension{
-						Raw: []byte(`{"is": "changed"}`),
-					},
-				},
-			}
-			policies.Items = append(policies.Items, *policy)
+				}
+				Expect(cc.Create(context.Background(), policy)).To(Succeed())
+
+				err = handler.Default(context.Background(), after)
+			})
+
+			It("should not throw an error", func() {
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should have injected the default variables", func() {
+				Expect(before).ToNot(Equal(after))
+				Expect(after.Spec.Variables.Raw).To(Equal([]byte(`{"is":"changed","name":"test"}`)))
+			})
 		})
 
-		It("should have changed", func() {
-			Expect(before).ToNot(Equal(after))
-			Expect(after.Spec.Variables.Raw).To(Equal([]byte(`{"is":"changed"}`)))
-			Expect(err).ToNot(HaveOccurred())
-		})
-	})
+		Context("and we have matching namespace selector but no initial variables", func() {
+			BeforeEach(func() {
+				before.Spec.Variables.Raw = []byte("")
+				after = before.DeepCopy()
 
-	Context("we have a matching namespace policy and existing variables", func() {
-		BeforeEach(func() {
-			before = fixtures.NewValidBucketConfiguration("test", "test")
-			before.Spec.Variables.Raw = []byte(`{"name":"existing"}`)
-
-			policies = &terraformv1alpha1.PolicyList{}
-			policy := fixtures.NewPolicy("test")
-			policy.Spec.Defaults = []terraformv1alpha1.DefaultVariables{
-				{
-					Selector: terraformv1alpha1.DefaultVariablesSelector{
-						Namespace: &metav1.LabelSelector{
-							MatchLabels: map[string]string{"app": "test"},
+				policy := fixtures.NewPolicy("test")
+				policy.Spec.Defaults = []terraformv1alpha1.DefaultVariables{
+					{
+						Selector: terraformv1alpha1.DefaultVariablesSelector{
+							Namespace: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"app": "test"},
+							},
+						},
+						Variables: runtime.RawExtension{
+							Raw: []byte(`{"foo": "bar"}`),
 						},
 					},
-					Variables: runtime.RawExtension{
-						Raw: []byte(`{"foo": "bar"}`),
-					},
-				},
-			}
-			policies.Items = append(policies.Items, *policy)
+				}
+				Expect(cc.Create(context.Background(), policy)).To(Succeed())
+
+				err = handler.Default(context.Background(), after)
+			})
+
+			It("should not throw an error", func() {
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should have changed", func() {
+				Expect(before).ToNot(Equal(after))
+				Expect(after.Spec.Variables.Raw).To(Equal([]byte(`{"foo":"bar"}`)))
+			})
 		})
 
-		It("should have changed", func() {
-			Expect(before).ToNot(Equal(after))
-			Expect(after.Spec.Variables.Raw).To(Equal([]byte(`{"foo":"bar","name":"existing"}`)))
-			Expect(err).ToNot(HaveOccurred())
-		})
-	})
+		Context("and we have module selectors", func() {
+			var policy *terraformv1alpha1.Policy
 
-	Context("we have a module policy", func() {
-		BeforeEach(func() {
-			before = fixtures.NewValidBucketConfiguration("test", "test")
-			before.Spec.Variables.Raw = []byte(`{"name":"existing"}`)
+			BeforeEach(func() {
+				before.Spec.Variables.Raw = []byte(`{"name":"existing"}`)
+				after = before.DeepCopy()
 
-			policies = &terraformv1alpha1.PolicyList{}
-			policy := fixtures.NewPolicy("test")
-			policy.Spec.Defaults = []terraformv1alpha1.DefaultVariables{
-				{
-					Selector: terraformv1alpha1.DefaultVariablesSelector{
-						Modules: []string{before.Spec.Module},
-					},
-					Variables: runtime.RawExtension{
-						Raw: []byte(`{"foo": "bar"}`),
-					},
-				},
-			}
-			policies.Items = append(policies.Items, *policy)
-		})
-
-		It("should have changed", func() {
-			Expect(before).ToNot(Equal(after))
-			Expect(after.Spec.Variables.Raw).To(Equal([]byte(`{"foo":"bar","name":"existing"}`)))
-			Expect(err).ToNot(HaveOccurred())
-		})
-	})
-
-	Context("we have have multiple selectors", func() {
-		BeforeEach(func() {
-			before = fixtures.NewValidBucketConfiguration("test", "test")
-			before.Spec.Variables.Raw = []byte(`{"name":"existing"}`)
-
-			policies = &terraformv1alpha1.PolicyList{}
-			policy := fixtures.NewPolicy("test")
-			policy.Spec.Defaults = []terraformv1alpha1.DefaultVariables{
-				{
-					Selector: terraformv1alpha1.DefaultVariablesSelector{
-						Modules: []string{before.Spec.Module},
-						Namespace: &metav1.LabelSelector{
-							MatchLabels: map[string]string{"app": "test"},
+				policy = fixtures.NewPolicy("test")
+				policy.Spec.Defaults = []terraformv1alpha1.DefaultVariables{
+					{
+						Selector: terraformv1alpha1.DefaultVariablesSelector{
+							Modules: []string{before.Spec.Module},
+						},
+						Variables: runtime.RawExtension{
+							Raw: []byte(`{"foo": "bar"}`),
 						},
 					},
-					Variables: runtime.RawExtension{
-						Raw: []byte(`{"foo": "bar"}`),
-					},
-				},
-			}
-			policies.Items = append(policies.Items, *policy)
+				}
+			})
+
+			Context("which is not matching", func() {
+				BeforeEach(func() {
+					policy.Spec.Defaults[0].Selector.Modules = []string{"not-matching"}
+					Expect(cc.Create(context.Background(), policy)).To(Succeed())
+
+					err = handler.Default(context.Background(), after)
+				})
+
+				It("should not throw an error", func() {
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("should not have changed", func() {
+					Expect(before).To(Equal(after))
+					Expect(after.Spec.Variables.Raw).To(Equal([]byte(`{"name":"existing"}`)))
+				})
+			})
+
+			Context("which is matching", func() {
+				BeforeEach(func() {
+					Expect(cc.Create(context.Background(), policy)).To(Succeed())
+
+					err = handler.Default(context.Background(), after)
+				})
+
+				It("should not throw an error", func() {
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("should have changed", func() {
+					Expect(before).ToNot(Equal(after))
+					Expect(after.Spec.Variables.Raw).To(Equal([]byte(`{"foo":"bar","name":"existing"}`)))
+				})
+			})
 		})
 
-		It("should have changed", func() {
-			Expect(before).ToNot(Equal(after))
-			Expect(after.Spec.Variables.Raw).To(Equal([]byte(`{"foo":"bar","name":"existing"}`)))
-			Expect(err).ToNot(HaveOccurred())
-		})
-	})
+		Context("and we are using multiple selectors", func() {
+			var policy *terraformv1alpha1.Policy
 
-	Context("we have have multiple selectors and does not match", func() {
-		BeforeEach(func() {
-			before = fixtures.NewValidBucketConfiguration("test", "test")
-			before.Spec.Variables.Raw = []byte(`{"name":"existing"}`)
+			BeforeEach(func() {
+				before.Spec.Variables.Raw = []byte(`{"name":"existing"}`)
+				after = before.DeepCopy()
 
-			policies = &terraformv1alpha1.PolicyList{}
-			policy := fixtures.NewPolicy("test")
-			policy.Spec.Defaults = []terraformv1alpha1.DefaultVariables{
-				{
-					Selector: terraformv1alpha1.DefaultVariablesSelector{
-						Modules: []string{before.Spec.Module},
-						Namespace: &metav1.LabelSelector{
-							MatchLabels: map[string]string{"app": "no_match"},
+				policy = fixtures.NewPolicy("test")
+				policy.Spec.Defaults = []terraformv1alpha1.DefaultVariables{
+					{
+						Selector: terraformv1alpha1.DefaultVariablesSelector{
+							Modules: []string{before.Spec.Module},
+							Namespace: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"app": "test"},
+							},
 						},
+						Variables: runtime.RawExtension{
+							Raw: []byte(`{"foo": "bar"}`),
+						},
+						Secrets: []string{"test"},
 					},
-					Variables: runtime.RawExtension{
-						Raw: []byte(`{"foo": "bar"}`),
+				}
+			})
+
+			Context("which is not matching", func() {
+				BeforeEach(func() {
+					policy.Spec.Defaults[0].Selector.Modules = []string{"which_does_not_match"}
+					Expect(cc.Create(context.Background(), policy)).To(Succeed())
+
+					err = handler.Default(context.Background(), after)
+				})
+
+				It("should not throw an error", func() {
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("should not have changed", func() {
+					Expect(before).To(Equal(after))
+					Expect(before.Spec.Variables.Raw).To(Equal([]byte(`{"name":"existing"}`)))
+					Expect(after.Spec.Variables.Raw).To(Equal([]byte(`{"name":"existing"}`)))
+				})
+			})
+
+			Context("which is matching", func() {
+				BeforeEach(func() {
+					Expect(cc.Create(context.Background(), policy)).To(Succeed())
+
+					err = handler.Default(context.Background(), after)
+				})
+
+				It("should not throw an error", func() {
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("should have changed", func() {
+					Expect(before).ToNot(Equal(after))
+					Expect(before.Spec.Variables.Raw).To(Equal([]byte(`{"name":"existing"}`)))
+					Expect(after.Spec.Variables.Raw).To(Equal([]byte(`{"foo":"bar","name":"existing"}`)))
+				})
+			})
+		})
+
+		Context("with a policy defining default secrets", func() {
+			BeforeEach(func() {
+				before.Spec.Variables.Raw = []byte(`{"name":"existing"}`)
+				after = before.DeepCopy()
+
+				policy := fixtures.NewPolicy("test")
+				policy.Spec.Defaults = []terraformv1alpha1.DefaultVariables{
+					{
+						Secrets: []string{"test"},
 					},
-				},
-			}
-			policies.Items = append(policies.Items, *policy)
+				}
+
+				err = handler.Default(context.Background(), after)
+			})
+
+			It("should not throw an error", func() {
+				Expect(err).ToNot(HaveOccurred())
+			})
+
+			It("should not have changed", func() {
+				Expect(before).To(Equal(after))
+				Expect(after.Spec.Variables.Raw).To(Equal([]byte(`{"name":"existing"}`)))
+				Expect(err).ToNot(HaveOccurred())
+			})
 		})
 
-		It("should have changed", func() {
-			Expect(before).To(Equal(after))
-			Expect(after.Spec.Variables.Raw).To(Equal([]byte(`{"name":"existing"}`)))
-			Expect(err).ToNot(HaveOccurred())
-		})
-	})
+		Context("with no provider reference defined in the configuration", func() {
+			var provider *terraformv1alpha1.Provider
 
-	Context("the policy is defining default secrets not variables", func() {
-		BeforeEach(func() {
-			before = fixtures.NewValidBucketConfiguration("test", "test")
-			before.Spec.Variables.Raw = []byte(`{"name":"existing"}`)
+			BeforeEach(func() {
+				before.Spec.ProviderRef.Name = ""
+				after = before.DeepCopy()
 
-			policies = &terraformv1alpha1.PolicyList{}
-			policy := fixtures.NewPolicy("test")
-			policy.Spec.Defaults = []terraformv1alpha1.DefaultVariables{
-				{
-					Secrets: []string{"test"},
-				},
-			}
-			policies.Items = append(policies.Items, *policy)
-		})
+				secret := fixtures.NewValidAWSProviderSecret("terraform-system", "default")
+				provider = fixtures.NewValidAWSReadyProvider("default", secret)
+				provider.Annotations = map[string]string{
+					terraformv1alpha1.DefaultProviderAnnotation: "true",
+				}
 
-		It("should not have changed", func() {
-			Expect(before).To(Equal(after))
-			Expect(after.Spec.Variables.Raw).To(Equal([]byte(`{"name":"existing"}`)))
-			Expect(err).ToNot(HaveOccurred())
-		})
-	})
+				Expect(cc.Create(context.Background(), secret)).To(Succeed())
+			})
 
-	Context("and the policy contains default secrets and variables", func() {
-		BeforeEach(func() {
-			before = fixtures.NewValidBucketConfiguration("test", "test")
-			before.Spec.Variables.Raw = []byte(`{"name":"existing"}`)
+			Context("and no default provider defined", func() {
+				BeforeEach(func() {
+					provider.Annotations = map[string]string{}
+					Expect(cc.Create(context.Background(), provider)).To(Succeed())
 
-			policies = &terraformv1alpha1.PolicyList{}
-			policy := fixtures.NewPolicy("test")
-			policy.Spec.Defaults = []terraformv1alpha1.DefaultVariables{
-				{
-					Selector: terraformv1alpha1.DefaultVariablesSelector{
-						Modules: []string{before.Spec.Module},
-					},
-					Variables: runtime.RawExtension{
-						Raw: []byte(`{"name": "new"}`),
-					},
-					Secrets: []string{"test"},
-				},
-			}
-			policies.Items = append(policies.Items, *policy)
-		})
+					err = handler.Default(context.Background(), after)
+				})
 
-		It("should have changed", func() {
-			Expect(before).ToNot(Equal(after))
-			Expect(after.Spec.Variables.Raw).To(Equal([]byte(`{"name":"new"}`)))
-			Expect(err).ToNot(HaveOccurred())
+				It("should not throw an error", func() {
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("should not have changed", func() {
+					Expect(before).To(Equal(after))
+					Expect(after.Spec.ProviderRef.Name).To(Equal(""))
+				})
+			})
+
+			Context("and a default provider defined", func() {
+				BeforeEach(func() {
+					Expect(cc.Create(context.Background(), provider)).To(Succeed())
+
+					err = handler.Default(context.Background(), after)
+				})
+
+				It("should not throw an error", func() {
+					Expect(err).ToNot(HaveOccurred())
+				})
+
+				It("should have changed", func() {
+					Expect(before).ToNot(Equal(after))
+					Expect(after.Spec.ProviderRef.Name).To(Equal(provider.Name))
+					Expect(before.Spec.ProviderRef.Name).To(BeEmpty())
+				})
+			})
+
+			Context("and multiple default providers defined", func() {
+				BeforeEach(func() {
+					additional := fixtures.NewValidAWSReadyProvider("additional", &v1.Secret{})
+					additional.Annotations = map[string]string{
+						terraformv1alpha1.DefaultProviderAnnotation: "true",
+					}
+					Expect(cc.Create(context.Background(), provider)).To(Succeed())
+					Expect(cc.Create(context.Background(), additional)).To(Succeed())
+
+					err = handler.Default(context.Background(), after)
+				})
+
+				It("should throw an error", func() {
+					Expect(err).To(HaveOccurred())
+					Expect(err.Error()).To(Equal("only one provider can be default, please contact your administrator"))
+				})
+
+				It("should have not changed", func() {
+					Expect(before).To(Equal(after))
+				})
+			})
 		})
 	})
 })


### PR DESCRIPTION
This feature enabled platform administrators to set a Provider as default via an annotation. For Configuration's which have not specified the `spec.providerRef.name`, the default is automatically added. Validation has also been added to ensure only one Provider is default at any one time.

```yaml
  ---
  apiVersion: terraform.appvia.io/v1alpha1
  kind: Provider
  metadata:
    name: aws
    annotations: 
      terranetes.appvia.io/default-provider: "true"
  spec:
    source: secret
    provider: aws
    secretRef:
      namespace: terraform-system
      name: aws
````
