### PR TITLE
[BUGFIX] - Azure Identity Binding

### DIFF
--- a/pkg/assets/job.yaml.tpl
+++ b/pkg/assets/job.yaml.tpl
@@ -20,6 +20,7 @@ spec:
         {{- range $key, $value := .Labels }}
         {{ $key }}: "{{ $value }}"
         {{- end }}
+        aadpodidbinding: terranetes-executor
     spec:
       # https://github.com/kubernetes/kubernetes/issues/74848
       restartPolicy: Never


### PR DESCRIPTION
Workload identity in Azure via AAD is performed via a binding, using a podselector https://azure.github.io/aad-pod-identity/docs/concepts/azureidentitybinding/#azureidentitybindingspec .. This requires a specific label `aadpodidbinding` on all job pods