### PR TITLE
[E2E] - Switching Dummy Module Requirements

### DIFF
--- a/test/e2e/assets/terraform/dummy/main.tf
+++ b/test/e2e/assets/terraform/dummy/main.tf
@@ -8,9 +8,9 @@ terraform {
   required_version = ">= 1.0"
 
   required_providers {
-    aws = {
-      source  = "hashicorp/aws"
-      version = ">= 4.62"
+    time = {
+      source = "hashicorp/time"
+      version = "0.9.1"
     }
   }
 }


### PR DESCRIPTION
The AWS providers is too large; choosing a smaller provider
