### PR TITLE
[FEATURE] - Allowing for Remapping of ValueFrom Inputs

### DIFF
--- a/charts/terranetes-controller/crds/terraform.appvia.io_configurations.yaml
+++ b/charts/terranetes-controller/crds/terraform.appvia.io_configurations.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: configurations.terraform.appvia.io
 spec:
   group: terraform.appvia.io
@@ -92,6 +91,9 @@ spec:
                       optional:
                         description: Optional indicates the secret can be optional, i.e if the secret does not exist, or the key is not contained in the secret, we ignore the error
                         type: boolean
+                      remapped:
+                        description: Remapped is an alternative name for the for the value - i.e. lets assume you have a secret with data.DH_HOST but you want to source the value as database_hostname
+                        type: string
                       secret:
                         description: Secret is the name of the secret in the configuration namespace
                         type: string

--- a/charts/terranetes-controller/crds/terraform.appvia.io_policies.yaml
+++ b/charts/terranetes-controller/crds/terraform.appvia.io_policies.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: policies.terraform.appvia.io
 spec:
   group: terraform.appvia.io

--- a/charts/terranetes-controller/crds/terraform.appvia.io_providers.yaml
+++ b/charts/terranetes-controller/crds/terraform.appvia.io_providers.yaml
@@ -2,8 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: providers.terraform.appvia.io
 spec:
   group: terraform.appvia.io

--- a/pkg/apis/terraform/v1alpha1/configuration_types.go
+++ b/pkg/apis/terraform/v1alpha1/configuration_types.go
@@ -200,9 +200,21 @@ type ValueFromSource struct {
 	// Key is the key in the secret which we should used for the value
 	// +kubebuilder:validation:Required
 	Key string `json:"key"`
+	// Remapped is an alternative name for the for the value - i.e. lets assume you
+	// have a secret with data.DH_HOST but you want to source the value as database_hostname
+	Remapped *string `json:"remapped,omitempty"`
 	// Secret is the name of the secret in the configuration namespace
 	// +kubebuilder:validation:Required
 	Secret string `json:"secret"`
+}
+
+// GetKeyName returns the name of the key but also checks for remapping
+func (v *ValueFromSource) GetKeyName() string {
+	if v.Remapped != nil && len(*v.Remapped) > 0 {
+		return *v.Remapped
+	}
+
+	return v.Key
 }
 
 // ConfigurationSpec defines the desired state of a terraform

--- a/pkg/controller/configuration/ensure.go
+++ b/pkg/controller/configuration/ensure.go
@@ -249,7 +249,7 @@ func (c *Controller) ensureValueFromSecret(configuration *terraformv1alpha1.Conf
 			}
 
 			if secret.Data != nil {
-				state.valueFrom[x.Key] = string(secret.Data[x.Key])
+				state.valueFrom[x.GetKeyName()] = string(secret.Data[x.Key])
 			}
 		}
 

--- a/pkg/register/assets.go
+++ b/pkg/register/assets.go
@@ -62,8 +62,7 @@ var _chartsTerranetesControllerCrdsTerraformAppviaIo_configurationsYaml = []byte
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: configurations.terraform.appvia.io
 spec:
   group: terraform.appvia.io
@@ -152,6 +151,9 @@ spec:
                       optional:
                         description: Optional indicates the secret can be optional, i.e if the secret does not exist, or the key is not contained in the secret, we ignore the error
                         type: boolean
+                      remapped:
+                        description: Remapped is an alternative name for the for the value - i.e. lets assume you have a secret with data.DH_HOST but you want to source the value as database_hostname
+                        type: string
                       secret:
                         description: Secret is the name of the secret in the configuration namespace
                         type: string
@@ -315,8 +317,7 @@ var _chartsTerranetesControllerCrdsTerraformAppviaIo_policiesYaml = []byte(`apiV
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: policies.terraform.appvia.io
 spec:
   group: terraform.appvia.io
@@ -723,8 +724,7 @@ var _chartsTerranetesControllerCrdsTerraformAppviaIo_providersYaml = []byte(`api
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.11.3
-  creationTimestamp: null
+    controller-gen.kubebuilder.io/version: v0.11.4
   name: providers.terraform.appvia.io
 spec:
   group: terraform.appvia.io
@@ -968,7 +968,6 @@ var _webhooksManifestsYaml = []byte(`---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   name: mutating-webhook-configuration
 webhooks:
 - admissionReviewVersions:
@@ -995,7 +994,6 @@ webhooks:
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  creationTimestamp: null
   name: validating-webhook-configuration
 webhooks:
 - admissionReviewVersions:


### PR DESCRIPTION
Currently there is no way to remap the inputs from a secret into a new name. Lets take the example were you have a secret containing DB_HOST but you want to use `database_hostname` as the input to the module. With this PR users now have the ability to remap the inputs as they see fit

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: mysecret
data:
  DB_HOST: value
```

You can use in the Configuration as `database_hostname` like

```yaml
apiVersion: terraform.appvia.io/v1alpha1
kind: Configuration
metadata:
  name: bucket
spec:
  module: https://github.com/terraform-aws-modules/terraform-aws-rds.git?ref=v3.1.0
  providerRef:
    name: aws
  valueFrom:
    - secret: mysecret
      key: DB_HOST
      remapped: database_hostname
      optional: false
```
