### PR TITLE
[FEATURE] - Renaming ValueFrom Secret Name

### DIFF
--- a/examples/configuration.yaml
+++ b/examples/configuration.yaml
@@ -33,6 +33,20 @@ spec:
   providerRef:
     name: aws
 
+  # Allows you to source in terraform inputs from one of more kubernetes secrets
+  valueFrom:
+    - secret: database_secret
+      # Is the key inside the secret i.e. data.<NAME>
+      key: DB_HOST
+      # Is optional but recommended. This specifies the name of the variable presented
+      # to terraform. Note, by default if left blank the key is used instead. You can also
+      # remap names where i.e DB_HOST and be remapped to database_hostname when consumed
+      name: database_hostname
+      # Indicates if the secret is optional - by default, any unresolved secret will defer
+      # execution and wait for the secret to become available. By setting to true, the controller
+      # will ignore a missing secret and or key
+      optional: true
+
   writeConnectionSecretToRef:
     name: test
     keys:

--- a/pkg/apis/terraform/v1alpha1/configuration_types.go
+++ b/pkg/apis/terraform/v1alpha1/configuration_types.go
@@ -200,21 +200,22 @@ type ValueFromSource struct {
 	// Key is the key in the secret which we should used for the value
 	// +kubebuilder:validation:Required
 	Key string `json:"key"`
-	// Remapped is an alternative name for the for the value - i.e. lets assume you
-	// have a secret with data.DH_HOST but you want to source the value as database_hostname
-	Remapped *string `json:"remapped,omitempty"`
+	// Name is the name which we use when injecting the value into the terraform code
+	// i.e. the secret maye contain data.DB_HOST but you call this database_hostname. Note,
+	// for backwards compatiability if no name is provided, we using the key at the name
+	Name string `json:"name,omitempty"`
 	// Secret is the name of the secret in the configuration namespace
 	// +kubebuilder:validation:Required
 	Secret string `json:"secret"`
 }
 
-// GetKeyName returns the name of the key but also checks for remapping
-func (v *ValueFromSource) GetKeyName() string {
-	if v.Remapped != nil && len(*v.Remapped) > 0 {
-		return *v.Remapped
+// GetName returns the name or the key if not set
+func (v *ValueFromSource) GetName() string {
+	if len(v.Name) == 0 {
+		return v.Key
 	}
 
-	return v.Key
+	return v.Name
 }
 
 // ConfigurationSpec defines the desired state of a terraform

--- a/pkg/controller/configuration/ensure.go
+++ b/pkg/controller/configuration/ensure.go
@@ -249,7 +249,7 @@ func (c *Controller) ensureValueFromSecret(configuration *terraformv1alpha1.Conf
 			}
 
 			if secret.Data != nil {
-				state.valueFrom[x.GetKeyName()] = string(secret.Data[x.Key])
+				state.valueFrom[x.GetName()] = string(secret.Data[x.Key])
 			}
 		}
 

--- a/pkg/controller/configuration/reconcile_test.go
+++ b/pkg/controller/configuration/reconcile_test.go
@@ -1099,9 +1099,8 @@ var _ = Describe("Configuration Controller", func() {
 					secret.Namespace = configuration.Namespace
 					secret.Name = "exists"
 					secret.Data = map[string][]byte{"DB_HOST": []byte("value")}
-					remapped := "database_host"
 
-					configuration.Spec.ValueFrom = []terraformv1alpha1.ValueFromSource{{Secret: "exists", Key: "DB_HOST", Remapped: &remapped}}
+					configuration.Spec.ValueFrom = []terraformv1alpha1.ValueFromSource{{Secret: "exists", Key: "DB_HOST", Name: "database_host"}}
 					Expect(ctrl.cc.Create(context.TODO(), configuration)).ToNot(HaveOccurred())
 					Expect(ctrl.cc.Create(context.TODO(), secret)).ToNot(HaveOccurred())
 


### PR DESCRIPTION
A previous feature added the ability to override the name of the variable when sourced from a secret (https://github.com/appvia/terranetes-controller/pull/723). The field felt wrong and so we renamed it to 'name' instead.
