### PR TITLE
[CI] - Adding Preload to Binary Builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,7 @@ jobs:
           go-version: '1.20'
       - name: Check Binaries
         run: |
+          make preload
           make source
           make step
           make tnctl


### PR DESCRIPTION
Adding the 'make preload' to the Github action when testing binary builds
