### PR TITLE
[BUILD] - Preload Controller, Reconcile on Revision Change

### DIFF
--- a/pkg/controller/preload/controller.go
+++ b/pkg/controller/preload/controller.go
@@ -69,6 +69,7 @@ func (c *Controller) Add(mgr manager.Manager) error {
 		Named(controllerName).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 10}).
 		WithEventFilter(&predicate.GenerationChangedPredicate{}).
+		WithEventFilter(&predicate.ResourceVersionChangedPredicate{}).
 		Watches(
 			&source.Kind{Type: &batchv1.Job{}},
 			handler.EnqueueRequestsFromMapFunc(func(o client.Object) []ctrl.Request {


### PR DESCRIPTION
Currently the preload controller is only set to reconcile on the generation change which is causing the status to update late. We can change this to resource version and just need to be careful around how the provider controller is configured not to create a loop
