### PR TITLE
[BUGFIX] - Additional Secrets in Setup Stage

### DIFF
--- a/pkg/assets/job.yaml.tpl
+++ b/pkg/assets/job.yaml.tpl
@@ -91,6 +91,11 @@ spec:
                 name: {{ . }}
                 optional: false
           {{- end }}
+          {{- range .ExecutorSecrets }}
+            - secretRef:
+                name: {{ . }}
+                optional: true
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: /run/config

--- a/pkg/controller/configuration/reconcile_test.go
+++ b/pkg/controller/configuration/reconcile_test.go
@@ -1482,6 +1482,11 @@ var _ = Describe("Configuration Controller", func() {
 			Expect(len(list.Items)).To(Equal(1))
 
 			job := list.Items[0]
+			Expect(job.Spec.Template.Spec.InitContainers[0].Name).To(Equal("setup"))
+			Expect(job.Spec.Template.Spec.InitContainers[0].EnvFrom).To(HaveLen(3))
+			Expect(job.Spec.Template.Spec.InitContainers[0].EnvFrom[1].SecretRef.Name).To(Equal("secret1"))
+			Expect(job.Spec.Template.Spec.InitContainers[0].EnvFrom[2].SecretRef.Name).To(Equal("secret2"))
+
 			Expect(job.Spec.Template.Spec.Containers).To(HaveLen(1))
 			Expect(job.Spec.Template.Spec.Containers[0].EnvFrom).To(HaveLen(3))
 			Expect(job.Spec.Template.Spec.Containers[0].EnvFrom[0].SecretRef.Name).To(Equal("aws"))


### PR DESCRIPTION
Currently when using the https://terranetes.appvia.io/terranetes-controller/admin/secrets/ command these secrets are not available to the setup init step, which makes it hard to use them as a common token auth private repositories
