### PR TITLE
[BUGFIX] - Policy Injected Secrets not in Deletion Stage

### DIFF
--- a/pkg/controller/configuration/delete.go
+++ b/pkg/controller/configuration/delete.go
@@ -78,6 +78,7 @@ func (c *Controller) ensureTerraformDestroy(configuration *terraformv1alpha1.Con
 		// @step: generate the destroy job
 		batch := jobs.New(configuration, state.provider)
 		runner, err := batch.NewTerraformDestroy(jobs.Options{
+			AdditionalJobSecrets: state.additionalJobSecrets,
 			AdditionalLabels: utils.MergeStringMaps(configuration.GetLabels(), map[string]string{
 				terraformv1alpha1.RetryAnnotation: configuration.GetAnnotations()[terraformv1alpha1.RetryAnnotation],
 			}),


### PR DESCRIPTION
When using policies to inject the secrets, there was a bug where the additional secret was not being injected in the Deletion stage. I've fixed the error and introduced coverage
