### PR TITLE
[HELM] Support for provider configuration in helm chart

### DIFF
--- a/charts/terranetes-controller/templates/providers.yaml
+++ b/charts/terranetes-controller/templates/providers.yaml
@@ -4,6 +4,7 @@
 {{- $name := $provider.name | required (printf ".Values.providers[%d].name is required." $index) -}}
 {{- $source := $provider.source | required (printf ".Values.providers[%d].source is required." $index) -}}
 {{- $preload := default $provider.preload "" }}
+{{- $configuration := default $provider.configuration "" }}
 ---
 apiVersion: terraform.appvia.io/v1alpha1
 kind: Provider
@@ -26,6 +27,10 @@ spec:
   {{- if $preload }}
   preload:
     {{ $preload | toYaml | nindent 4  }}
+  {{- end }}
+  {{- if $configuration }}
+  configuration:
+    {{- $configuration | toYaml | nindent 4  }}
   {{- end }}
   {{- if eq $provider.source "secret" }}
   secretRef:

--- a/charts/terranetes-controller/values.yaml
+++ b/charts/terranetes-controller/values.yaml
@@ -126,6 +126,8 @@ providers:
 #    serviceAccount: SERV
 #    # When using preload this is copied into the provider
 #    preload: {}
+#    # Additional provider configuration
+#    configuration: {}
 rbac:
   # Indicates we allow all service account in the controller namespace the role of
   # executor. This makes rolling out multiple providers backed to multiple services easier.


### PR DESCRIPTION
Configuration block is already supported in the Provider CRD however there was no support in the helm chart.  This adds the ability to specify a configuration block in Provider resources when using helm