### PR TITLE
[FEATURE] - Cloud Resource Update Available

### DIFF
--- a/charts/terranetes-controller/crds/terraform.appvia.io_cloudresources.yaml
+++ b/charts/terranetes-controller/crds/terraform.appvia.io_cloudresources.yaml
@@ -31,6 +31,9 @@ spec:
         - jsonPath: .status.costs.monthly
           name: Estimated
           type: string
+        - jsonPath: .status.
+          name: Update
+          type: string
         - jsonPath: .status.resourceStatus
           name: Synchronized
           type: string
@@ -351,6 +354,9 @@ spec:
                 resources:
                   description: Resources is the number of managed cloud resources which are currently under management. This field is taken from the terraform state itself.
                   type: integer
+                updateAvailable:
+                  description: UpdateAvailable indicates if there is a new version of the plan available
+                  type: string
               type: object
           type: object
       served: true

--- a/pkg/apis/terraform/v1alpha1/cloudresource_types.go
+++ b/pkg/apis/terraform/v1alpha1/cloudresource_types.go
@@ -151,6 +151,7 @@ func (c *CloudResourceSpec) HasValueFrom() bool {
 // +kubebuilder:printcolumn:name="Secret",type="string",JSONPath=".spec.writeConnectionSecretToRef.name"
 // +kubebuilder:printcolumn:name="Configuration",type="string",JSONPath=".status.configurationName"
 // +kubebuilder:printcolumn:name="Estimated",type="string",JSONPath=".status.costs.monthly"
+// +kubebuilder:printcolumn:name="Update",type="string",JSONPath=".status."
 // +kubebuilder:printcolumn:name="Synchronized",type="string",JSONPath=".status.resourceStatus"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 type CloudResource struct {
@@ -189,7 +190,11 @@ type CloudResourceStatus struct {
 	Resources int `json:"resources,omitempty"`
 	// ResourceStatus indicates the status of the resources and if the resources are insync with the
 	// configuration
+	// +kubebuilder:validation:Optional
 	ResourceStatus ResourceStatus `json:"resourceStatus,omitempty"`
+	// UpdateAvailable indicates if there is a new version of the plan available
+	// +kubebuilder:validation:Optional
+	UpdateAvailable string `json:"updateAvailable,omitempty"`
 }
 
 // GetNamespacedName returns the namespaced resource type

--- a/pkg/apis/terraform/v1alpha1/plan_types.go
+++ b/pkg/apis/terraform/v1alpha1/plan_types.go
@@ -45,9 +45,9 @@ type PlanRevision struct {
 	// Name is the name of the revision containing the configuration
 	//+kubebuilder:validation:Required
 	Name string `json:"name"`
-	// Version is the version of the revision
+	// Revision is the version of the revision
 	//+kubebuilder:validation:Required
-	Version string `json:"version"`
+	Revision string `json:"version"`
 }
 
 // PlanSpec defines the desired state for a context
@@ -80,7 +80,7 @@ func (c *Plan) ListRevisions() []string {
 	var revisions []string
 
 	for _, r := range c.Spec.Revisions {
-		revisions = append(revisions, r.Version)
+		revisions = append(revisions, r.Revision)
 	}
 
 	return revisions
@@ -89,7 +89,7 @@ func (c *Plan) ListRevisions() []string {
 // GetRevision returns the revision with the specified version
 func (c *Plan) GetRevision(version string) (PlanRevision, bool) {
 	for _, r := range c.Spec.Revisions {
-		if r.Version == version {
+		if r.Revision == version {
 			return r, true
 		}
 	}
@@ -100,7 +100,7 @@ func (c *Plan) GetRevision(version string) (PlanRevision, bool) {
 // HasRevision returns true if the plan has the specified revision
 func (c *Plan) HasRevision(version string) bool {
 	for _, x := range c.Spec.Revisions {
-		if x.Version == version {
+		if x.Revision == version {
 			return true
 		}
 	}
@@ -113,7 +113,7 @@ func (c *Plan) RemoveRevision(version string) {
 	var revisions []PlanRevision
 
 	for _, x := range c.Spec.Revisions {
-		if x.Version != version {
+		if x.Revision != version {
 			revisions = append(revisions, x)
 		}
 	}

--- a/pkg/cmd/tnctl/create/revision.go
+++ b/pkg/cmd/tnctl/create/revision.go
@@ -109,7 +109,7 @@ func NewRevisionCommand(factory cmd.Factory) *cobra.Command {
 	flags.BoolVar(&o.EnableDefaultVariables, "enable-default-variables", false, "Indicates if default variables should be included")
 	flags.StringVar(&o.Description, "description", "", "A human readable description of the revision and what is provides")
 	flags.StringVarP(&o.Name, "name", "n", "", "This name of the revision")
-	flags.StringVarP(&o.Revision, "version", "r", "", "The semvar version of this revision")
+	flags.StringVarP(&o.Revision, "revision", "r", "", "The semvar version of this revision")
 
 	return c
 }
@@ -266,7 +266,7 @@ func (o *RevisionCommand) GetRevision() error {
 	}
 
 	// @step: increment the version
-	if version, err := utils.GetVersionIncrement(plan.Status.Latest.Version); err != nil {
+	if version, err := utils.GetVersionIncrement(plan.Status.Latest.Revision); err != nil {
 		o.Revision = "REVISION"
 	} else {
 		o.Revision = version

--- a/pkg/controller/cloudresource/metrics.go
+++ b/pkg/controller/cloudresource/metrics.go
@@ -15,31 +15,25 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-package utils
+package cloudresource
 
-import "github.com/Masterminds/semver"
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
 
-// GetVersionIncrement returns either an error or the version increment
-func GetVersionIncrement(version string) (string, error) {
-	sem, err := semver.NewVersion(version)
-	if err != nil {
-		return "", err
-	}
-	updated := sem.IncPatch()
-
-	return updated.String(), nil
+func init() {
+	metrics.Registry.MustRegister(
+		cloudResourceUpdate,
+	)
 }
 
-// VersionLessThan returns either an error a bool indicating if the version is greater than the other
-func VersionLessThan(version string, other string) (bool, error) {
-	sem, err := semver.NewVersion(version)
-	if err != nil {
-		return false, err
-	}
-	otherSem, err := semver.NewVersion(other)
-	if err != nil {
-		return false, err
-	}
-
-	return sem.LessThan(otherSem), nil
-}
+var (
+	cloudResourceUpdate = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "cloudresource_update_available",
+			Help: "Indicates if the cloud resource has updates available and is running an older revision",
+		},
+		[]string{"namespace", "name"},
+	)
+)

--- a/pkg/controller/cloudresource/reconcile.go
+++ b/pkg/controller/cloudresource/reconcile.go
@@ -77,6 +77,7 @@ func (c *Controller) Reconcile(ctx context.Context, request reconcile.Request) (
 			c.ensurePlanExists(cloudresource, state),
 			c.ensureRevisionExists(cloudresource, state),
 			c.ensureConfigurationExists(cloudresource, state),
+			c.ensureUpdateStatus(cloudresource, state),
 			c.ensureConfigurationStatus(cloudresource, state),
 		})
 	if err != nil {

--- a/pkg/controller/plan/ensure.go
+++ b/pkg/controller/plan/ensure.go
@@ -48,7 +48,7 @@ func (c *Controller) ensureLatestOnPlan(plan *terraformv1alpha1.Plan) controller
 
 		var revision terraformv1alpha1.PlanRevision
 		for _, x := range plan.Spec.Revisions {
-			if x.Version == latest {
+			if x.Revision == latest {
 				revision = x
 			}
 		}

--- a/pkg/controller/plan/reconcile_test.go
+++ b/pkg/controller/plan/reconcile_test.go
@@ -67,12 +67,12 @@ var _ = Describe("Plan Controller", func() {
 			plan = fixtures.NewConfigurationPlan("test")
 			plan.Spec.Revisions = []terraformv1alpha1.PlanRevision{
 				{
-					Name:    "test",
-					Version: "0.0.1",
+					Name:     "test",
+					Revision: "0.0.1",
 				},
 				{
-					Name:    "test-1",
-					Version: "0.0.2",
+					Name:     "test-1",
+					Revision: "0.0.2",
 				},
 			}
 			Expect(cc.Create(context.Background(), plan)).To(Succeed())
@@ -104,8 +104,8 @@ var _ = Describe("Plan Controller", func() {
 			BeforeEach(func() {
 				plan.Spec.Revisions = []terraformv1alpha1.PlanRevision{
 					{
-						Name:    "test",
-						Version: "BAD",
+						Name:     "test",
+						Revision: "BAD",
 					},
 				}
 				Expect(cc.Update(context.Background(), plan)).To(Succeed())
@@ -169,7 +169,7 @@ var _ = Describe("Plan Controller", func() {
 				found, err := kubernetes.GetIfExists(context.Background(), cc, plan)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(found).To(BeTrue())
-				Expect(plan.Status.Latest.Version).To(Equal("0.0.2"))
+				Expect(plan.Status.Latest.Revision).To(Equal("0.0.2"))
 				Expect(plan.Status.Latest.Name).To(Equal("test-1"))
 			})
 		})

--- a/pkg/controller/revision/ensure.go
+++ b/pkg/controller/revision/ensure.go
@@ -45,8 +45,8 @@ func (c *Controller) ensurePlanExists(revision *terraformv1alpha1.Revision) cont
 
 		} else if !found {
 			plan.Spec.Revisions = []terraformv1alpha1.PlanRevision{{
-				Name:    revision.Name,
-				Version: revision.Spec.Plan.Revision,
+				Name:     revision.Name,
+				Revision: revision.Spec.Plan.Revision,
 			}}
 
 			if err := cc.Create(ctx, plan); err != nil {
@@ -67,8 +67,8 @@ func (c *Controller) ensurePlanExists(revision *terraformv1alpha1.Revision) cont
 
 		// @step: update the revision list
 		plan.Spec.Revisions = append(plan.Spec.Revisions, terraformv1alpha1.PlanRevision{
-			Name:    revision.Name,
-			Version: revision.Spec.Plan.Revision,
+			Name:     revision.Name,
+			Revision: revision.Spec.Plan.Revision,
 		})
 		if err := cc.Patch(ctx, plan, client.MergeFrom(original)); err != nil {
 			cond.Failed(err, "Failed to patch the configuration plan: %v", err)

--- a/pkg/controller/revision/reconcile_test.go
+++ b/pkg/controller/revision/reconcile_test.go
@@ -127,8 +127,8 @@ var _ = Describe("Revisions Controller", func() {
 				plan := fixtures.NewConfigurationPlan(revision.Spec.Plan.Name)
 				plan.Spec.Revisions = []terraformv1alpha1.PlanRevision{
 					{
-						Version: "v0.0.0",
-						Name:    "another",
+						Revision: "v0.0.0",
+						Name:     "another",
 					},
 				}
 				Expect(cc.Create(context.Background(), plan)).To(Succeed())
@@ -174,8 +174,8 @@ var _ = Describe("Revisions Controller", func() {
 				plan := fixtures.NewConfigurationPlan(revision.Spec.Plan.Name)
 				plan.Spec.Revisions = []terraformv1alpha1.PlanRevision{
 					{
-						Version: revision.Spec.Plan.Revision,
-						Name:    revision.Spec.Plan.Name,
+						Revision: revision.Spec.Plan.Revision,
+						Name:     revision.Spec.Plan.Name,
 					},
 				}
 				Expect(cc.Create(context.Background(), plan)).To(Succeed())
@@ -229,12 +229,12 @@ var _ = Describe("Revisions Controller", func() {
 			plan = fixtures.NewConfigurationPlan(revision.Spec.Plan.Name)
 			plan.Spec.Revisions = []terraformv1alpha1.PlanRevision{
 				{
-					Version: "0.0.0",
-					Name:    revision.Spec.Plan.Name,
+					Revision: "0.0.0",
+					Name:     revision.Spec.Plan.Name,
 				},
 				{
-					Version: revision.Spec.Plan.Revision,
-					Name:    revision.Spec.Plan.Name,
+					Revision: revision.Spec.Plan.Revision,
+					Name:     revision.Spec.Plan.Name,
 				},
 			}
 			Expect(cc.Create(context.Background(), plan)).To(Succeed())
@@ -263,8 +263,8 @@ var _ = Describe("Revisions Controller", func() {
 			BeforeEach(func() {
 				plan.Spec.Revisions = []terraformv1alpha1.PlanRevision{
 					{
-						Version: "0.0.0",
-						Name:    revision.Spec.Plan.Name,
+						Revision: "0.0.0",
+						Name:     revision.Spec.Plan.Name,
 					},
 				}
 				Expect(cc.Update(context.Background(), plan)).To(Succeed())

--- a/pkg/handlers/cloudresources/mutation.go
+++ b/pkg/handlers/cloudresources/mutation.go
@@ -83,11 +83,11 @@ func mutateOnRevision(ctx context.Context, cc client.Client, o *terraformv1alpha
 	if !found {
 		return fmt.Errorf("spec.plan.name resource %q not found", o.Spec.Plan.Name)
 	}
-	if plan.Status.Latest.Version == "" {
+	if plan.Status.Latest.Revision == "" {
 		return fmt.Errorf("spec.plan.name resource %q does not have a latest revision", o.Spec.Plan.Name)
 	}
 
-	o.Spec.Plan.Revision = plan.Status.Latest.Version
+	o.Spec.Plan.Revision = plan.Status.Latest.Revision
 
 	return nil
 }

--- a/pkg/handlers/cloudresources/mutation_test.go
+++ b/pkg/handlers/cloudresources/mutation_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Configuration Mutation", func() {
 			cloudresource.Spec.ProviderRef = &terraformv1alpha1.ProviderReference{Name: "aws"}
 
 			plan = fixtures.NewPlan(cloudresource.Spec.Plan.Name)
-			plan.Status.Latest.Version = "v1.0.0"
+			plan.Status.Latest.Revision = "v1.0.0"
 
 			cc = fake.NewClientBuilder().WithScheme(schema.GetScheme()).Build()
 			handler = &mutator{cc: cc}
@@ -110,7 +110,7 @@ var _ = Describe("Configuration Mutation", func() {
 
 			Context("when the plan does not have a latest version", func() {
 				BeforeEach(func() {
-					plan.Status.Latest.Version = ""
+					plan.Status.Latest.Revision = ""
 					Expect(cc.Update(context.Background(), plan)).To(Succeed())
 
 					err = handler.Default(context.Background(), cloudresource)

--- a/pkg/handlers/cloudresources/validation_test.go
+++ b/pkg/handlers/cloudresources/validation_test.go
@@ -167,7 +167,7 @@ var _ = Describe("Checking CloudResource Validation", func() {
 		})
 
 		It("should fail when revision not present in plan", func() {
-			plan.Spec.Revisions[0].Version = "v0.0.2"
+			plan.Spec.Revisions[0].Revision = "v0.0.2"
 			Expect(cc.Update(context.Background(), plan)).To(Succeed())
 
 			err := v.ValidateCreate(context.Background(), cloudresource)

--- a/pkg/register/assets.go
+++ b/pkg/register/assets.go
@@ -95,6 +95,9 @@ spec:
         - jsonPath: .status.costs.monthly
           name: Estimated
           type: string
+        - jsonPath: .status.
+          name: Update
+          type: string
         - jsonPath: .status.resourceStatus
           name: Synchronized
           type: string
@@ -415,6 +418,9 @@ spec:
                 resources:
                   description: Resources is the number of managed cloud resources which are currently under management. This field is taken from the terraform state itself.
                   type: integer
+                updateAvailable:
+                  description: UpdateAvailable indicates if there is a new version of the plan available
+                  type: string
               type: object
           type: object
       served: true

--- a/pkg/utils/semvar_test.go
+++ b/pkg/utils/semvar_test.go
@@ -34,3 +34,45 @@ func TestVersionIncrement(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "0.0.2", version)
 }
+
+func TestVersionLessThan(t *testing.T) {
+	cases := []struct {
+		Version string
+		Latest  string
+		Expect  bool
+	}{
+		{
+			Version: "v0.0.1",
+			Latest:  "v0.0.2",
+			Expect:  true,
+		},
+		{
+			Version: "v0.0.1",
+			Latest:  "v0.0.1",
+			Expect:  false,
+		},
+		{
+			Version: "v0.0.2",
+			Latest:  "v0.0.1",
+			Expect:  false,
+		},
+		{
+			Version: "v0.1.0",
+			Latest:  "v0.0.1",
+			Expect:  false,
+		},
+		{
+			Version: "v0.1.0",
+			Latest:  "v0.2.1",
+			Expect:  true,
+		},
+	}
+
+	for i, c := range cases {
+		result, err := VersionLessThan(c.Version, c.Latest)
+		assert.NoError(t, err)
+		assert.Equal(t, c.Expect, result, "case %d, version: %s, latest: %s, got: %T ",
+			i, c.Version, c.Latest, result,
+		)
+	}
+}

--- a/test/fixtures/revision.go
+++ b/test/fixtures/revision.go
@@ -35,8 +35,8 @@ func NewPlan(name string, revisions ...*terraformv1alpha1.Revision) *terraformv1
 
 	for _, revision := range revisions {
 		plan.Spec.Revisions = append(plan.Spec.Revisions, terraformv1alpha1.PlanRevision{
-			Name:    revision.Name,
-			Version: revision.Spec.Plan.Revision,
+			Name:     revision.Name,
+			Revision: revision.Spec.Plan.Revision,
 		})
 	}
 


### PR DESCRIPTION
Currently a consumer would not be aware if a Cloud Resource has updates availabe, without checking the plan. In the pull request we have added a prometheus metrics for monitoring purposes which tracks if an updates is available as well as a status flag which is show on the kubectl get cloudresource, indicates an update is available
