### PR TITLE
[FEATURE] - CLI Get Command

### DIFF
--- a/pkg/cmd/tnctl/get/generic.go
+++ b/pkg/cmd/tnctl/get/generic.go
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2023  Appvia Ltd <info@appvia.io>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package get
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+
+	"github.com/gertd/go-pluralize"
+	"github.com/spf13/cobra"
+
+	"github.com/appvia/terranetes-controller/pkg/cmd"
+)
+
+var (
+	cc = pluralize.NewClient()
+)
+
+// ConfigurationOptions provides information required to retrieve a cloud resource
+type ConfigurationOptions struct {
+	cmd.Factory
+	// Name is the name of the cloud resource
+	Name string
+	// Namespace is the namespace of the cloud resource
+	Namespace string
+	// Output is the output format
+	Output string
+	// AllNamespaces is a flag to indicate whether to retrieve cloud resources from all namespaces
+	AllNamespaces bool
+}
+
+// NewGetResourceCommand returns a new cobra command
+func NewGetResourceCommand(factory cmd.Factory, resource string) *cobra.Command {
+	o := &ConfigurationOptions{Factory: factory}
+	singular := cc.Singular(strings.Split(resource, ".")[0])
+	plural := cc.Plural(singular)
+
+	cmd := &cobra.Command{
+		Use:     fmt.Sprintf("%s [OPTIONS] [NAME]", singular),
+		Aliases: []string{plural},
+		Short:   fmt.Sprintf("Used to retrieve %s/s from the cluster", singular),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			options := []string{
+				"get",
+				resource,
+			}
+			if o.Namespace != "" {
+				options = append(options, "--namespace", o.Namespace)
+			}
+			if len(args) > 0 {
+				options = append(options, args...)
+			}
+			if o.Output != "" {
+				options = append(options, "--output", o.Output)
+			}
+			if o.AllNamespaces {
+				options = append(options, "--all-namespaces")
+			}
+
+			c := exec.CommandContext(cmd.Context(), "kubectl", options...)
+			c.Stdout = factory.GetStreams().Out
+			c.Stderr = factory.GetStreams().ErrOut
+			c.Stdin = factory.GetStreams().In
+
+			return c.Run()
+		},
+	}
+
+	flags := cmd.Flags()
+	flags.StringVarP(&o.Namespace, "namespace", "n", "", "Namespace to retrieve the resource from")
+	flags.StringVarP(&o.Output, "output", "o", "", "The output format. Supported formats are: json|yaml|wide")
+	flags.BoolVarP(&o.AllNamespaces, "all-namespaces", "A", false, "Retrieve cloud resources from all namespaces")
+
+	return cmd
+}

--- a/pkg/cmd/tnctl/get/get.go
+++ b/pkg/cmd/tnctl/get/get.go
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2023  Appvia Ltd <info@appvia.io>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package get
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	terraformv1alpha1 "github.com/appvia/terranetes-controller/pkg/apis/terraform/v1alpha1"
+	"github.com/appvia/terranetes-controller/pkg/cmd"
+)
+
+// Command are the options for the command
+type Command struct {
+	cmd.Factory
+}
+
+// NewCommand creates and returns a new command
+func NewCommand(factory cmd.Factory) *cobra.Command {
+	c := &cobra.Command{
+		Use:   "get KIND",
+		Short: "Used to retrieve a list of resources",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	for _, resource := range []string{
+		"cloudresources",
+		"configurations",
+		"contexts",
+		"policies",
+		"plans",
+		"revisions",
+	} {
+		c.AddCommand(
+			NewGetResourceCommand(factory,
+				fmt.Sprintf("%s.%s", resource, terraformv1alpha1.SchemeGroupVersion.Group),
+			),
+		)
+	}
+
+	return c
+}

--- a/pkg/cmd/tnctl/tnctl.go
+++ b/pkg/cmd/tnctl/tnctl.go
@@ -35,12 +35,12 @@ import (
 	"github.com/appvia/terranetes-controller/pkg/cmd/tnctl/create"
 	"github.com/appvia/terranetes-controller/pkg/cmd/tnctl/describe"
 	"github.com/appvia/terranetes-controller/pkg/cmd/tnctl/generate"
+	"github.com/appvia/terranetes-controller/pkg/cmd/tnctl/get"
 	"github.com/appvia/terranetes-controller/pkg/cmd/tnctl/kubectl"
 	"github.com/appvia/terranetes-controller/pkg/cmd/tnctl/logs"
 	"github.com/appvia/terranetes-controller/pkg/cmd/tnctl/retry"
 	"github.com/appvia/terranetes-controller/pkg/cmd/tnctl/search"
 	"github.com/appvia/terranetes-controller/pkg/cmd/tnctl/state"
-	"github.com/appvia/terranetes-controller/pkg/cmd/tnctl/workflow"
 	"github.com/appvia/terranetes-controller/pkg/version"
 )
 
@@ -77,11 +77,11 @@ func New(factory cmd.Factory) *cobra.Command {
 		config.NewCommand(factory),
 		approve.NewCommand(factory),
 		build.NewCommand(factory),
+		get.NewCommand(factory),
 		kubectl.NewCommand(factory),
 		search.NewCommand(factory),
 		convert.NewCommand(factory),
 		create.NewCommand(factory),
-		workflow.NewCommand(factory),
 		describe.NewCommand(factory),
 		generate.NewCommand(factory),
 		state.NewCommand(factory),


### PR DESCRIPTION
This is largely just a convience command and it's annoying jumpiny between kubectl and tnctl. This feature simply calls the 'kubectl get' command for each of the resource types
