### PR TITLE
[BUGFIX] - Configuration Resource Status

### DIFF
--- a/pkg/controller/configuration/ensure.go
+++ b/pkg/controller/configuration/ensure.go
@@ -1087,6 +1087,8 @@ func (c *Controller) ensureTerraformApply(configuration *terraformv1alpha1.Confi
 			cond.ActionRequired("Waiting for terraform apply annotation to be set to true")
 			// update the ready condition to reflect the new state
 			readyCond.InProgress("Waiting for changes to be approved")
+			// update the resource status
+			configuration.Status.ResourceStatus = terraformv1alpha1.ResourcesOutOfSync
 
 			return reconcile.Result{}, controller.ErrIgnore
 

--- a/pkg/controller/configuration/reconcile_test.go
+++ b/pkg/controller/configuration/reconcile_test.go
@@ -2752,6 +2752,11 @@ terraform {
 				Expect(cond.Message).To(Equal("Waiting for changes to be approved"))
 			})
 
+			It("should indicate the resource out of sync", func() {
+				Expect(cc.Get(context.TODO(), configuration.GetNamespacedName(), configuration)).ToNot(HaveOccurred())
+				Expect(configuration.Status.ResourceStatus).To(Equal(terraformv1alpha1.ResourcesOutOfSync))
+			})
+
 			It("should have raised a kubernetes event", func() {
 				Expect(recorder.Events).To(HaveLen(1))
 				Expect(recorder.Events[0]).To(Equal("(apps/bucket) Warning Action Required: Waiting for terraform apply annotation to be set to true"))


### PR DESCRIPTION
The configuration controller was not setting the .status.resourceStatus correctly; which meant resources which were out of sync and waiting for a approval was not showing in the status (just the overall .status.condition). The logic was correctly i.e. it was still waiting for approval, just not indicating on the status
