### PR TITLE
[BUGFIX] - Generating Checkov Policy Per Constraint

### DIFF
--- a/pkg/cmd/tnctl/convert/configuration.go
+++ b/pkg/cmd/tnctl/convert/configuration.go
@@ -334,7 +334,7 @@ func (o *ConfigurationCommand) resolveConfiguration(ctx context.Context) error {
 	// @step: we need to prompt the user to ask if they want use to resolve them?
 	if o.Configuration.Spec.ValueFrom.HasSecretReferences() {
 		if err := survey.AskOne(&survey.Confirm{
-			Message: "The Configuration contains references to Secrets, do you want to resolve them?",
+			Message: "The resource contains references to Secrets, do you want to resolve them?",
 		}, &answer); err != nil {
 			return err
 		}
@@ -371,7 +371,7 @@ func (o *ConfigurationCommand) resolveConfiguration(ctx context.Context) error {
 
 	if o.Configuration.Spec.ValueFrom.HasContextReferences() {
 		if err := survey.AskOne(&survey.Confirm{
-			Message: "The Configuration contains references to Contexts, do you want to resolve them?",
+			Message: "The resource contains references to Contexts, do you want to resolve them?",
 		}, &answer); err != nil {
 			return err
 		}


### PR DESCRIPTION
The current implmentation is using namespace match to generate the checkov policy - it makes more sense to test the revision against all possible policies in the cluster; plus has the benefit on not relying on the need to speak to a cluster when checking
