### PR TITLE
[FEATURE] - Ignore Local Directories on Module Policy Verification

### DIFF
--- a/pkg/utils/slices.go
+++ b/pkg/utils/slices.go
@@ -17,7 +17,10 @@
 
 package utils
 
-import "sort"
+import (
+	"sort"
+	"strings"
+)
 
 // MaxChars returns the maximum character length of a list of strings
 func MaxChars(slice string, max int) string {
@@ -29,6 +32,17 @@ func MaxChars(slice string, max int) string {
 	}
 
 	return slice[:max]
+}
+
+// ContainsPrefix checks a list has a value with the prefixes
+func ContainsPrefix(v string, l []string) bool {
+	for _, x := range l {
+		if strings.HasPrefix(v, x) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // Contains checks a list has a value in it

--- a/pkg/utils/slices_test.go
+++ b/pkg/utils/slices_test.go
@@ -28,6 +28,12 @@ func TestMaxChars(t *testing.T) {
 	assert.Equal(t, "hel", v)
 }
 
+func TestContainsPrefix(t *testing.T) {
+	assert.True(t, ContainsPrefix("/tmp/revision", []string{"/", "."}))
+	assert.True(t, ContainsPrefix(".", []string{"/", "."}))
+	assert.False(t, ContainsPrefix("abc", []string{"def"}))
+}
+
 func TestContainsOK(t *testing.T) {
 	list := []string{"a", "b", "c"}
 


### PR DESCRIPTION
Ignoring the verification if the module spec has a local directory
