### PR TITLE
[BUGFIX] Use leader elections and run two replicas by default to avoid webhook issues on upgrades

### DIFF
--- a/charts/terranetes-controller/values.yaml
+++ b/charts/terranetes-controller/values.yaml
@@ -3,7 +3,7 @@ nameOverride: ""
 # Override the naming scheme and force to this name
 fullnameOverride: ""
 # The number of replicas for the controller
-replicaCount: 1
+replicaCount: 2
 # Settings for the controller
 controller:
   # Is the port the builds apis

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -124,7 +124,7 @@ func New(cfg *rest.Config, config Config) (*Server, error) {
 		Cache: cache.Options{
 			SyncPeriod: &config.ResyncPeriod,
 		},
-		LeaderElection:                false,
+		LeaderElection:                true,
 		LeaderElectionID:              "controller.terraform.appvia.io",
 		LeaderElectionNamespace:       ns,
 		LeaderElectionReleaseOnCancel: true,


### PR DESCRIPTION
Attempting to address #1120 by running two replicas and using leadership elections