### PR TITLE
Add support for HTTP auth

### DIFF
--- a/cmd/source/source.go
+++ b/cmd/source/source.go
@@ -295,7 +295,8 @@ func netRCPath() string {
 }
 
 func setupNetRC(location string) error {
-	uri, err := url.Parse(location)
+	trimmedLocation := strings.TrimPrefix(strings.TrimPrefix(location, "https::"), "http::")
+	uri, err := url.Parse(trimmedLocation)
 	if err != nil {
 		return fmt.Errorf("failed to parse location URL: %w", err)
 	}

--- a/cmd/source/source.go
+++ b/cmd/source/source.go
@@ -306,7 +306,7 @@ func setupNetRC(location string) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal netrc config: %w", err)
 	}
-	err = os.WriteFile(netRCPath(), netrcData, 0760)
+	err = os.WriteFile(netRCPath(), netrcData, 0600)
 	if err != nil {
 		return fmt.Errorf("failed to write netrc file: %w", err)
 	}

--- a/cmd/source/source_test.go
+++ b/cmd/source/source_test.go
@@ -183,6 +183,26 @@ func TestSetupNetRC(t *testing.T) {
 	login user
 	password mypass`,
 		},
+		{
+			Location: "http::http://myhost/file.tar.gz",
+			Environment: map[string]string{
+				"HTTP_USERNAME": "user",
+				"HTTP_PASSWORD": "mypass",
+			},
+			ExpectedNetRC: `machine myhost
+	login user
+	password mypass`,
+		},
+		{
+			Location: "https::http://myhost/file.tar.gz",
+			Environment: map[string]string{
+				"HTTP_USERNAME": "user",
+				"HTTP_PASSWORD": "mypass",
+			},
+			ExpectedNetRC: `machine myhost
+	login user
+	password mypass`,
+		},
 	}
 
 	for i, c := range cases {

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Masterminds/sprig/v3 v3.2.3
 	github.com/aws/aws-sdk-go v1.50.1
 	github.com/bbalet/stopwords v1.0.0
+	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d
 	github.com/enescakir/emoji v1.0.0
 	github.com/evanphx/json-patch v5.8.1+incompatible
 	github.com/fatih/color v1.16.0
@@ -86,7 +87,6 @@ require (
 	github.com/ashanbrown/forbidigo v1.6.0 // indirect
 	github.com/ashanbrown/makezero v1.1.1 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/bkielbasa/cyclop v1.2.1 // indirect
 	github.com/blizzy78/varnamelen v0.8.0 // indirect
 	github.com/bombsimon/wsl/v3 v3.4.0 // indirect

--- a/pkg/assets/job.yaml.tpl
+++ b/pkg/assets/job.yaml.tpl
@@ -115,6 +115,9 @@ spec:
             - /bin/terraform
           args:
             - init
+          env:
+            - name: HOME
+              value: /data
           envFrom:
           {{- range .Secrets.AdditionalSecrets }}
             - secretRef:
@@ -202,6 +205,8 @@ spec:
           - --on-error=/run/steps/terraform.failed
           - --on-success=/run/steps/terraform.complete
         env:
+          - name: HOME
+            value: /data
           - name: CONFIGURATION_NAME
             value: {{ .Configuration.Name }}
           - name: CONFIGURATION_NAMESPACE

--- a/pkg/controller/configuration/reconcile_test.go
+++ b/pkg/controller/configuration/reconcile_test.go
@@ -1650,9 +1650,9 @@ terraform {
 			Expect(container.EnvFrom[0].SecretRef).ToNot(BeNil())
 			Expect(container.EnvFrom[0].SecretRef.Name).To(Equal("aws"))
 
-			Expect(len(container.Env)).To(Equal(5))
-			Expect(container.Env[4].Name).To(Equal("TERRAFORM_STATE_NAME"))
-			Expect(container.Env[4].Value).To(Equal(configuration.GetTerraformStateSecretName()))
+			Expect(len(container.Env)).To(Equal(6))
+			Expect(container.Env[5].Name).To(Equal("TERRAFORM_STATE_NAME"))
+			Expect(container.Env[5].Value).To(Equal(configuration.GetTerraformStateSecretName()))
 
 			Expect(container.VolumeMounts[0].Name).To(Equal("run"))
 			Expect(container.VolumeMounts[1].Name).To(Equal("source"))
@@ -2918,9 +2918,9 @@ terraform {
 				Expect(container.EnvFrom[0].SecretRef).ToNot(BeNil())
 				Expect(container.EnvFrom[0].SecretRef.Name).To(Equal("aws"))
 
-				Expect(len(container.Env)).To(Equal(5))
-				Expect(container.Env[4].Name).To(Equal("TERRAFORM_STATE_NAME"))
-				Expect(container.Env[4].Value).To(Equal(configuration.GetTerraformStateSecretName()))
+				Expect(len(container.Env)).To(Equal(6))
+				Expect(container.Env[5].Name).To(Equal("TERRAFORM_STATE_NAME"))
+				Expect(container.Env[5].Value).To(Equal(configuration.GetTerraformStateSecretName()))
 
 				Expect(container.VolumeMounts[0].Name).To(Equal("run"))
 				Expect(container.VolumeMounts[1].Name).To(Equal("source"))


### PR DESCRIPTION
Hello there 👋 

While evaluating terranetes I noticed it wasn't possible to use HTTP basic auth for downloading modules. Terraform/go-getter allows HTTP auth using the [`.netrc` file](https://developer.hashicorp.com/terraform/language/modules/sources#http-urls).

In this PR I used `HTTP_USERNAME` and `HTTP_PASSWORD` envs to write a `.netrc` file right before downloading the source. This file is written by default to the $HOME dir and I also had to change the job template to configure the same $HOME on all containers. This allows Terraform init/plan/apply to share the auth credentials, which is required when the source module includes instances to other private modules.

