### PR TITLE
[BUG] - Namespace Selectory for Secrets

### DIFF
--- a/charts/terranetes-controller/values.yaml
+++ b/charts/terranetes-controller/values.yaml
@@ -39,7 +39,7 @@ controller:
     # image to use for infracost
     infracost: infracost/infracost:ci-0.10.33
     # policy is image for policy
-    policy: bridgecrew/checkov:3.2.8-pyston
+    policy: bridgecrew/checkov:3.2.10
     # preload is the image to use for preload data jobs
     preload: ghcr.io/appvia/terranetes-executor:v0.4.5
     # is the controller image

--- a/pkg/controller/configuration/ensure.go
+++ b/pkg/controller/configuration/ensure.go
@@ -483,7 +483,7 @@ func (c *Controller) ensurePolicyDefaultsExist(configuration *terraformv1alpha1.
 			return reconcile.Result{}, nil
 		}
 
-		// @step: we need to retrieve the namespace from the cache 
+		// @step: we need to retrieve the namespace from the cache
 		namespace, found := c.cache.Get(configuration.Namespace)
 		if !found {
 			log.WithFields(log.Fields{
@@ -499,12 +499,12 @@ func (c *Controller) ensurePolicyDefaultsExist(configuration *terraformv1alpha1.
 				continue
 			}
 
-			// @step: iterate the defaults and check if we have any secrets 
+			// @step: iterate the defaults and check if we have any secrets
 			for _, x := range state.policies.Items[i].Spec.Defaults {
 				switch {
 				case len(x.Secrets) == 0:
 					continue
-				
+
 				case len(x.Selector.Modules) == 0 && x.Selector.Namespace == nil:
 					list = append(list, x.Secrets...)
 				}
@@ -516,7 +516,7 @@ func (c *Controller) ensurePolicyDefaultsExist(configuration *terraformv1alpha1.
 						cond.Failed(err, "Failed to check against the policy: %q", state.policies.Items[i].Name)
 
 						return reconcile.Result{}, err
-					} 
+					}
 					if match {
 						list = append(list, x.Secrets...)
 					}

--- a/pkg/controller/configuration/reconcile_test.go
+++ b/pkg/controller/configuration/reconcile_test.go
@@ -373,7 +373,6 @@ var _ = Describe("Configuration Controller Default Injection", func() {
 			})
 		})
 
-
 		Context("and we have default secrets", func() {
 			Context("and no job for the terraform plan exists", func() {
 				BeforeEach(func() {


### PR DESCRIPTION
The documentation was incorrect, there was probably the intent to add this but my fish brain forgot to raise the pull request. 

```yaml
apiVersion: terraform.appvia.io/v1alpha1
kind: Policy
metadata:
  name: default-authentication
spec:
  defaults:
    # Can be used to filter on configuration module sources
    modules:
      - github.com/appvia/terraform-aws-myprivaterepo:.*
    namespace:
      # Use expressions to match on namespace labels
      matchExpressions:
        - key: kubernetes.io/metadata.name
          operator: Exists
    secrets:
      - auth_key
```

The above as referenced in the documentation will inject based on labels selectors of the Configurations namespace. The code however was never implemented; only module selectors were added. 

https://terranetes.appvia.io/terranetes-controller/admin/defaults/#secrets
