### PR TITLE
Allow custom CA secret name in Helm chart

### DIFF
--- a/charts/terranetes-controller/templates/ca.yaml
+++ b/charts/terranetes-controller/templates/ca.yaml
@@ -1,10 +1,10 @@
 {{- if .Values.controller.webhooks.ca }}
-{{- $secret := lookup "v1" "Secret" .Release.Namespace "ca" }}
+{{- $secret := lookup "v1" "Secret" .Release.Namespace .Values.controller.webhooks.caSecret }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: ca
+  name: {{ .Values.controller.webhooks.caSecret }}
   labels:
     {{- include "terranetes-controller.labels" . | nindent 4 }}
 type: Opaque

--- a/charts/terranetes-controller/templates/deployment.yaml
+++ b/charts/terranetes-controller/templates/deployment.yaml
@@ -34,11 +34,11 @@ spec:
       serviceAccountName: terranetes-controller
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- if .Values.controller.webhooks.ca }}
+      {{- if .Values.controller.webhooks.enabled }}
       volumes:
         - name: ca
           secret:
-            secretName: ca
+            secretName: {{ .Values.controller.webhooks.caSecret }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -100,7 +100,7 @@ spec:
               containerPort: {{ .Values.controller.webhooks.port }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- if .Values.controller.webhooks.ca }}
+          {{- if .Values.controller.webhooks.enabled }}
           volumeMounts:
             - name: ca
               readOnly: true

--- a/charts/terranetes-controller/values.yaml
+++ b/charts/terranetes-controller/values.yaml
@@ -91,8 +91,10 @@ controller:
     enabled: true
     # is the port the webhooks is running
     port: 10250
-    # creates the certificate authority
+    # creates the certificate authority secret
     ca: true
+    # secret name containing certificate authority and server certificate
+    caSecret: "ca"
     # name of the file containing the certificate authority
     tlsAuthority: /certs/ca.pem
     # name of the file containing the tls certificate


### PR DESCRIPTION
This PR updates the helm chart allowing a custom CA secret to be used with the terranetes-controller. This is useful when we don't want the Helm chart to manage the CA secret and instead have it managed by external tools.