### PR TITLE
Prefix webhook names with controller name

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -61,6 +61,7 @@ func main() {
 	flags.BoolVar(&config.EnableWatchers, "enable-watchers", true, "Indicates we create watcher jobs in the configuration namespaces")
 	flags.BoolVar(&config.EnableWebhooks, "enable-webhooks", true, "Indicates we should register the webhooks")
 	flags.BoolVar(&config.RegisterCRDs, "register-crds", true, "Indicates the controller to register its own CRDs")
+	flags.BoolVar(&config.EnableWebhookPrefix, "enable-webhook-prefix", false, "Indicates the controller should prefix webhook configuration names with the controller name")
 	flags.DurationVar(&config.DriftControllerInterval, "drift-controller-interval", 5*time.Minute, "Is the check interval for the controller to search for configurations which should be checked for drift")
 	flags.DurationVar(&config.DriftInterval, "drift-interval", 3*time.Hour, "The minimum duration the controller will wait before triggering a drift check")
 	flags.DurationVar(&config.ResyncPeriod, "resync-period", 5*time.Hour, "The resync period for the controller")

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -52,6 +52,8 @@ type Config struct {
 	EnableWatchers bool
 	// EnableTerraformVersions indicates if configurations can override the default terraform version
 	EnableTerraformVersions bool
+	// EnableWebhookPrefix enables adding the "terranetes-controller-" prefix to webhook configuration names
+	EnableWebhookPrefix bool
 	// ExecutorImage is the image to use for the executor
 	ExecutorImage string
 	// ExecutorSecrets is a list of additional secrets to be added to the executor


### PR DESCRIPTION
Currently, webhook configurations are named `validating-webhook-configuration` and `mutating-webhook-configuration`. Since webhooks are global resources these names can easily conflict with webhooks for other controllers installed on the cluster.

This PR adds the option of using the `terranetes-controller-` prefix when creating those webhooks. Since this can be a breaking change for existing installations of Terranetes I added it under a controller flag with the default being to use the unprefixed names.