### PR TITLE
Expose webhook prefix config on helm chart

### DIFF
--- a/charts/terranetes-controller/templates/deployment.yaml
+++ b/charts/terranetes-controller/templates/deployment.yaml
@@ -68,6 +68,7 @@ spec:
             - --enable-terraform-versions={{ .Values.controller.enableTerraformVersions }}
             - --enable-watchers={{ .Values.controller.enableWatchers }}
             - --enable-webhooks={{ .Values.controller.webhooks.enabled }}
+            - --enable-webhook-prefix={{ .Values.controller.webhooks.prefix }}
             - --executor-image={{ .Values.controller.images.executor }}
             {{- range .Values.controller.executorSecrets }}
             - --executor-secret={{ . }}

--- a/charts/terranetes-controller/values.yaml
+++ b/charts/terranetes-controller/values.yaml
@@ -89,6 +89,8 @@ controller:
   webhooks:
     # enables the webhooks
     enabled: true
+    # enables prefixing the webhook configuration names with the controller name
+    prefix: false
     # is the port the webhooks is running
     port: 10250
     # creates the certificate authority secret


### PR DESCRIPTION
This is a follow-up to https://github.com/appvia/terranetes-controller/pull/1263 exposing the webhook prefix configuration on the Helm chart.