### PR TITLE
[FIX] - Provider Backend

### DIFF
--- a/pkg/controller/configuration/reconcile.go
+++ b/pkg/controller/configuration/reconcile.go
@@ -90,8 +90,8 @@ func (c *Controller) Reconcile(ctx context.Context, request reconcile.Request) (
 		result, err := controller.DefaultEnsureHandler.Run(ctx, c.cc, configuration,
 			[]controller.EnsureFunc{
 				c.ensureCapturedState(configuration, state),
-				c.ensureCustomBackendTemplate(configuration, state),
 				c.ensureProviderReady(configuration, state),
+				c.ensureCustomBackendTemplate(configuration, state),
 				c.ensurePolicyDefaultsExist(configuration, state),
 				c.ensureValueFromSecret(configuration, state),
 				c.ensureAuthenticationSecret(configuration, state),


### PR DESCRIPTION
The custom backend was not being picked up in the destroy phase; this was being caused due to the order of the ensure funcs. The provider would have been nil going into the ensureCustomBackendTemplate() and thus fallen into the default backend, which is kubernetes