### PR TITLE
Only update last reconcile status when there are resource changes

### DIFF
--- a/pkg/controller/ensure_test.go
+++ b/pkg/controller/ensure_test.go
@@ -1,0 +1,188 @@
+package controller
+
+import (
+	"context"
+	"io"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	corev1alpha1 "github.com/appvia/terranetes-controller/pkg/apis/core/v1alpha1"
+	terraformv1alpha1 "github.com/appvia/terranetes-controller/pkg/apis/terraform/v1alpha1"
+	"github.com/appvia/terranetes-controller/pkg/schema"
+)
+
+func TestEnsure(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Running Test Suite")
+}
+
+var _ = Describe("EnsureRunner", func() {
+	logrus.SetOutput(io.Discard)
+
+	ctx := context.TODO()
+
+	var (
+		cc            client.Client
+		configuration *terraformv1alpha1.Configuration
+		ensure        EnsureRunner
+	)
+
+	BeforeEach(func() {
+		configuration = &terraformv1alpha1.Configuration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "c1",
+				Generation: 2,
+			},
+		}
+		cc = fake.NewClientBuilder().
+			WithScheme(schema.GetScheme()).
+			WithStatusSubresource(&terraformv1alpha1.Configuration{}).
+			WithRuntimeObjects(configuration).
+			Build()
+	})
+
+	When("Run is called", func() {
+		When("resource is reconciled for the first time", func() {
+			It("sets initial reconcile status", func() {
+				result, err := ensure.Run(ctx, cc, configuration, nil)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result).To(Equal(reconcile.Result{}))
+
+				Expect(configuration.Status.CommonStatus.LastReconcile).NotTo(BeNil())
+				Expect(configuration.Status.CommonStatus.LastReconcile.Generation).To(Equal(int64(2)))
+				Expect(configuration.Status.CommonStatus.LastReconcile.Time).NotTo(BeZero())
+
+				Expect(configuration.Status.CommonStatus.LastSuccess).NotTo(BeNil())
+				Expect(configuration.Status.CommonStatus.LastSuccess.Generation).To(Equal(int64(2)))
+				Expect(configuration.Status.CommonStatus.LastSuccess.Time).NotTo(BeZero())
+			})
+		})
+
+		When("resource already reconciled", func() {
+			var originalTime metav1.Time
+			BeforeEach(func() {
+				originalTime = metav1.Time{Time: time.Now().Add(-time.Hour).Truncate(time.Second)}
+				configuration.Status = terraformv1alpha1.ConfigurationStatus{
+					CommonStatus: corev1alpha1.CommonStatus{
+						LastReconcile: &corev1alpha1.LastReconcileStatus{
+							Generation: 2,
+							Time:       originalTime,
+						},
+						LastSuccess: &corev1alpha1.LastReconcileStatus{
+							Generation: 2,
+							Time:       originalTime,
+						},
+					},
+				}
+				cc = fake.NewClientBuilder().
+					WithScheme(schema.GetScheme()).
+					WithStatusSubresource(&terraformv1alpha1.Configuration{}).
+					WithRuntimeObjects(configuration).
+					Build()
+			})
+
+			When("resource is unchanged", func() {
+				It("does not update status", func() {
+					result, err := ensure.Run(ctx, cc, configuration, nil)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result).To(Equal(reconcile.Result{}))
+
+					Expect(configuration.Status.CommonStatus.LastReconcile).NotTo(BeNil())
+					Expect(configuration.Status.CommonStatus.LastReconcile.Time).To(Equal(originalTime))
+
+					Expect(configuration.Status.CommonStatus.LastSuccess).NotTo(BeNil())
+					Expect(configuration.Status.CommonStatus.LastSuccess.Time).To(Equal(originalTime))
+				})
+			})
+
+			When("resource generation has changed", func() {
+				BeforeEach(func() {
+					configuration.Generation = 9
+					cc = fake.NewClientBuilder().
+						WithScheme(schema.GetScheme()).
+						WithStatusSubresource(&terraformv1alpha1.Configuration{}).
+						WithRuntimeObjects(configuration).
+						Build()
+				})
+
+				It("updates the status", func() {
+					result, err := ensure.Run(ctx, cc, configuration, nil)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result).To(Equal(reconcile.Result{}))
+
+					Expect(configuration.Status.CommonStatus.LastReconcile).NotTo(BeNil())
+					Expect(configuration.Status.CommonStatus.LastReconcile.Generation).To(Equal(int64(9)))
+					Expect(configuration.Status.CommonStatus.LastReconcile.Time).NotTo(Equal(originalTime))
+
+					Expect(configuration.Status.CommonStatus.LastSuccess).NotTo(BeNil())
+					Expect(configuration.Status.CommonStatus.LastSuccess.Generation).To(Equal(int64(9)))
+					Expect(configuration.Status.CommonStatus.LastSuccess.Time).NotTo(Equal(originalTime))
+				})
+			})
+
+			When("ensurefunc updates resource", func() {
+				It("updates the status", func() {
+					result, err := ensure.Run(ctx, cc, configuration, []EnsureFunc{
+						func(ctx context.Context) (reconcile.Result, error) {
+							configuration.Spec.Module = "m1"
+							return reconcile.Result{}, nil
+						},
+					})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result).To(Equal(reconcile.Result{}))
+
+					Expect(configuration.Status.CommonStatus.LastReconcile).NotTo(BeNil())
+					Expect(configuration.Status.CommonStatus.LastReconcile.Time).NotTo(Equal(originalTime))
+
+					Expect(configuration.Status.CommonStatus.LastSuccess).NotTo(BeNil())
+					Expect(configuration.Status.CommonStatus.LastSuccess.Time).NotTo(Equal(originalTime))
+				})
+			})
+
+			When("ensurefunc changes resource and requests requeue", func() {
+				It("updates only last reconcile", func() {
+					result, err := ensure.Run(ctx, cc, configuration, []EnsureFunc{
+						func(ctx context.Context) (reconcile.Result, error) {
+							configuration.Spec.Module = "m1"
+							return reconcile.Result{Requeue: true}, nil
+						},
+					})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result).To(Equal(reconcile.Result{Requeue: true}))
+
+					Expect(configuration.Status.CommonStatus.LastReconcile).NotTo(BeNil())
+					Expect(configuration.Status.CommonStatus.LastReconcile.Time).NotTo(Equal(originalTime))
+
+					Expect(configuration.Status.CommonStatus.LastSuccess).NotTo(BeNil())
+					Expect(configuration.Status.CommonStatus.LastSuccess.Time).To(Equal(originalTime))
+				})
+			})
+
+			When("ensurefunc does not change resource but requests requeue", func() {
+				It("does not update status", func() {
+					result, err := ensure.Run(ctx, cc, configuration, []EnsureFunc{
+						func(ctx context.Context) (reconcile.Result, error) {
+							return reconcile.Result{Requeue: true}, nil
+						},
+					})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(result).To(Equal(reconcile.Result{Requeue: true}))
+
+					Expect(configuration.Status.CommonStatus.LastReconcile).NotTo(BeNil())
+					Expect(configuration.Status.CommonStatus.LastReconcile.Time).To(Equal(originalTime))
+
+					Expect(configuration.Status.CommonStatus.LastSuccess).NotTo(BeNil())
+					Expect(configuration.Status.CommonStatus.LastSuccess.Time).To(Equal(originalTime))
+				})
+			})
+		})
+	})
+})


### PR DESCRIPTION
While rolling out Terranetes I noticed that on some of our clusters (the ones with a larger number of Configuration resources) terranetes was continuously reconciling all resources even when there were no changes. The `drift` controller was causing this and there was a significant increase in the CPU usage for the terranetes-controller pod. This can be seen on this graph for the workqueue add rate:
<img width="1565" alt="Screenshot 2024-03-04 at 12 14 27" src="https://github.com/appvia/terranetes-controller/assets/11041/21895f3e-498f-4ef5-a482-56404120f926">

Upon further investigation, I noticed this was caused by the drift controller continuously updating the timestamp at `Configuration.Status.LastReconcile.Time`. The reason the issue only manifested on some clusters was due to how long the drift reconciler takes to run.

Since the `Configuration.Status.LastReconcile.Time` field is serialized with seconds resolution (e.g. "2024-03-04T14:00:19Z") if the reconciler takes less than 1 second to run, the serialized value will be the same and the Configuration resource will remain unchanged. This is the scenario I saw on some smaller clusters where this issue wasn't present.

However, if reconciling takes longer than 1 second, the controller will update the resource causing the informer to notice the change and enqueue a new reconciliation, which can take more than 1s again and the process repeats ad infinitum. This could happen due to too many Configuration resources or other constraints to the controller Pod.

Now to the proposed fix, I can see two different paths for a solution here. The first would be adding an event filter to the drift controller to ignore changes to the lastReconcile timestamps. The problem with this is that it would only apply to the Terranetes controllers, and every external controllers/operators watching Terranetes resources would also have to apply that same filter to avoid being spammed with reconciliations.

The other option is the one I'm submitting on this PR. I propose the LastReconcile timestamps be updated only if there are other changes to the resource as changing only the timestamp isn't helpful to watchers. This is similar to the behavior of timestamps on Conditions which only track the latest change. I also added some basic unit tests to verify this new behavior.



