### PR TITLE
Add helm chart values for extra controller arguments

### DIFF
--- a/charts/terranetes-controller/templates/deployment.yaml
+++ b/charts/terranetes-controller/templates/deployment.yaml
@@ -91,7 +91,9 @@ spec:
             - --tls-key={{ .Values.controller.webhooks.tlsKey }}
             - --webhooks-port={{ .Values.controller.webhooks.port }}
             {{- end }}
-            - --verbose=true
+            {{- range $key, $value := .Values.controller.extraArgs }}
+            - --{{ $key }}={{ $value }}
+            {{- end }}
           ports:
             - name: metrics
               containerPort: {{ .Values.controller.metricsPort }}

--- a/charts/terranetes-controller/values.yaml
+++ b/charts/terranetes-controller/values.yaml
@@ -105,6 +105,10 @@ controller:
     tlsDir: /certs
     # name of the file containing the tls private key
     tlsKey: tls-key.pem
+  # extraArgs is used for passing additional command line arguments to the
+  # controller.
+  extraArgs:
+    verbose: true
 networkPolicies:
   # Indicates we should create the network policies
   enabled: true


### PR DESCRIPTION
This PR adds the `.Values.controller.extraArgs` values to the Helm chart. The idea is to use it for flags that aren't required and do not warrant a dedicated Values entry due to not being common enough. Also, this might simplify the release process when adding new args making them available without requiring a Helm chart release.
