### PR TITLE
Add configuration labels to destroy jobs

### DIFF
--- a/pkg/controller/configuration/delete.go
+++ b/pkg/controller/configuration/delete.go
@@ -94,6 +94,7 @@ func (c *Controller) ensureTerraformDestroy(configuration *terraformv1alpha1.Con
 			AdditionalJobLabels: utils.MergeStringMaps(
 				c.ControllerJobLabels,
 				state.provider.JobLabels(),
+				configuration.GetLabels(),
 				map[string]string{
 					terraformv1alpha1.RetryAnnotation: configuration.GetAnnotations()[terraformv1alpha1.RetryAnnotation],
 				}),


### PR DESCRIPTION
I noticed `destroy` Jobs weren't including the configuration labels. Those labels are already present on `plan` and `apply` Jobs, having them also on `destroy` shouldn't cause any harm and makes kubectl querying easier.