### PR TITLE
[BUGFIX] - Namespace Cache

### DIFF
--- a/pkg/controller/configuration/controller.go
+++ b/pkg/controller/configuration/controller.go
@@ -173,8 +173,7 @@ func (c *Controller) Add(mgr manager.Manager) error {
 	}
 
 	c.cc = mgr.GetClient()
-
-	c.cache = pcache.New(12*time.Hour, 10*time.Minute)
+	c.cache = pcache.New(24*time.Hour, 10*time.Minute)
 	c.cache.OnEvicted(func(key string, _ interface{}) {
 		// ensure we have some logging for when a namespace is evicted
 		log.WithField("namespace", key).Warn("evicted namespace from cache")


### PR DESCRIPTION
Its probably something silly, but after much trying to replicate the issue, i’m can’t see how the cache could not contain the namespace. The fact it appears to happen ever 11 hours is probably related to the cache expiration https://github.com/appvia/terranetes-controller/pull/1350/files#diff-53a4e552527dc2eab7835e6b4fdff466da76827aa2e7fa940c6b6c107d281bcbL177 … I’ve implemented in the change a fallback to to an direct api call, if the item is not in the cache. Perhaps long term it’s easier to just go with that and avoid any of the issues with caching at all .. 