### PR TITLE
Ensure custom backend templates have the correct indent

### DIFF
--- a/charts/terranetes-controller/templates/backend.yaml
+++ b/charts/terranetes-controller/templates/backend.yaml
@@ -6,5 +6,5 @@ metadata:
   name: {{ .Values.controller.backend.name }}
 stringData:
   backend.tf: |
-    {{ .Values.controller.backend.template | nindent 4 | trim}}
+{{ .Values.controller.backend.template | indent 4 }}
 {{- end }}

--- a/charts/terranetes-controller/templates/backend.yaml
+++ b/charts/terranetes-controller/templates/backend.yaml
@@ -6,5 +6,5 @@ metadata:
   name: {{ .Values.controller.backend.name }}
 stringData:
   backend.tf: |
-    {{ .Values.controller.backend.template }}
+    {{ .Values.controller.backend.template | nindent 4 | trim}}
 {{- end }}


### PR DESCRIPTION
Trying to use a multi line string to set the terraform backend config results in a parsing error. The helm template needs to up updated to set the indent manually so that multi line string from the values.yaml has the correct indentation.

```
YAML parse error on terranetes-controller/templates/backend.yaml: error converting YAML to JSON: yaml: line 9: could not find expected ':'
```