### PR TITLE
[BUILD] - Golang Lint Skipped Directories

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,7 @@ run:
   go: "1.21"
   tests: false
   timeout: 10m
-  skip-dirs:
+  exclude-dirs:
     - hack
     - tests
 


### PR DESCRIPTION
The skip-dirs has been deprecated and replaced with exclude-dirs
