### PR TITLE
fix: allow using a different namespace for the auth

### DIFF
--- a/pkg/controller/configuration/ensure.go
+++ b/pkg/controller/configuration/ensure.go
@@ -452,7 +452,12 @@ func (c *Controller) ensureAuthenticationSecret(configuration *terraformv1alpha1
 		}
 
 		secret := &v1.Secret{}
-		secret.Namespace = configuration.Namespace
+		if configuration.Spec.Auth.Namespace == "" {
+			secret.Namespace = configuration.Namespace
+		} else {
+			secret.Namespace = configuration.Spec.Auth.Namespace
+		}
+
 		secret.Name = configuration.Spec.Auth.Name
 
 		found, err := kubernetes.GetIfExists(ctx, c.cc, secret)


### PR DESCRIPTION
Use different namespace for fetching the `auth` secret for Git in case it's specified

Use case:

revision ->
```
apiVersion: terraform.appvia.io/v1alpha1
kind: Revision
metadata:
  name: my-revision
  namespace: my-ns
spec:
  # more config
  configuration:
    auth:
      name: auth
      namespace: other-ns
```

In this case the controller fails because it can't find the `auth` secret in `my-ns`.

My PR checks if `spec.configuration.auth.namespace` is set and use this namespace in case it's present to get the secret