### PR TITLE
[FIX] - Webhook Name

### DIFF
--- a/charts/terranetes-controller/templates/webhooks.yaml
+++ b/charts/terranetes-controller/templates/webhooks.yaml
@@ -18,7 +18,7 @@ webhooks:
         namespace: {{ .Release.Namespace }}
         path: /validate/terraform.appvia.io/namespaces
     failurePolicy: Fail
-    name: cloudresources.terraform.appvia.io
+    name: namespaces.terraform.appvia.io
     rules:
       - apiGroups:
           - ""


### PR DESCRIPTION
We have a duplicate name in the webhook, when namespace protection is enabled
