### PR TITLE
[HELM] - Fixed typo in values.yaml

### DIFF
--- a/charts/terranetes-controller/values.yaml
+++ b/charts/terranetes-controller/values.yaml
@@ -65,7 +65,7 @@ controller:
     # is the name of config map holding a override to the job template
     job: ""
   # a collection of labels which are added to all jobs
-  jobsLabels: {}
+  jobLabels: {}
   # is the image pull policy
   imagePullPolicy: IfNotPresent
   # indicate we create the watcher jobs in user namespace, these allow users


### PR DESCRIPTION
Inside the deployment.yaml and in other locations inside the project, `jobLabels` is used.