### PR TITLE
[HELM] - Job Label Chart Fix

### DIFF
--- a/charts/terranetes-controller/Chart.yaml
+++ b/charts/terranetes-controller/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: terranetes-controller
 description: Controller used to provision a terraform workflow within kubernetes
 type: application
-version: v0.7.22
+version: v0.7.23
 appVersion: v0.4.16
 sources:
   - https://github.com/appvia/terranetes-controller


### PR DESCRIPTION
The current helm chart has a typo in the 'controller.jobsLabels', this should have been 'controller.jobLabels', which is what the actual template references
