### PR TITLE
add a rety option to the step command

### DIFF
--- a/cmd/step/main.go
+++ b/cmd/step/main.go
@@ -148,9 +148,9 @@ func Run(ctx context.Context, step Step) error {
 			if attempt > 0 {
 				backoff := calculateBackoff(step.RetryMinBackoff, step.RetryMaxJitter)
 				log.WithFields(log.Fields{
-					"attempt": attempt,
-					"command": i,
-					"backoff": backoff,
+					"attempt":       attempt,
+					"command-index": i,
+					"backoff":       backoff,
 				}).Info("retrying command")
 
 				select {
@@ -165,8 +165,8 @@ func Run(ctx context.Context, step Step) error {
 			cmd.Env = os.Environ()
 
 			logger := log.WithFields(log.Fields{
-				"command": i,
-				"attempt": attempt,
+				"command-index": i,
+				"attempt":       attempt,
 			})
 
 			stdout, err := cmd.StdoutPipe()

--- a/cmd/step/main.go
+++ b/cmd/step/main.go
@@ -87,6 +87,7 @@ func calculateBackoff(minBackoff, maxJitter time.Duration) time.Duration {
 	if maxJitter <= 0 {
 		return minBackoff
 	}
+	//nolint:gosec // math/rand is acceptable here as jitter value is not used for security purposes
 	jitter := time.Duration(rand.Int63n(int64(maxJitter)))
 	return minBackoff + jitter
 }

--- a/cmd/step/main.go
+++ b/cmd/step/main.go
@@ -71,7 +71,8 @@ func main() {
 	flags.StringSliceVarP(&step.UploadFile, "upload", "u", []string{}, "Upload file as a kubernetes secret")
 	flags.StringVar(&step.WaitFile, "wait-on", "", "The path to a file to indicate this step can be run")
 	flags.StringSliceVarP(&step.Commands, "command", "c", []string{}, "Command to execute")
-
+	flags.IntVar(&step.RetryAttempts, "retry-attempts", 0, "Number of times to retry the commands")
+	flags.DurationVar(&step.RetryBackoff, "retry-backoff", 0, "Duration to wait between retry attempts")
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "[Error] %s\n", err)
 
@@ -128,49 +129,78 @@ func Run(ctx context.Context, step Step) error {
 	}
 
 	for i, command := range step.Commands {
-		//nolint:gosec
-		cmd := exec.CommandContext(ctx, step.Shell, "-c", command)
-		cmd.Env = os.Environ()
+		attempt := 0
+		var lastErr error
 
-		logger := log.WithField("command", i)
+		for attempt <= step.RetryAttempts {
+			if attempt > 0 {
+				log.WithFields(log.Fields{
+					"attempt": attempt,
+					"command": i,
+					"backoff": step.RetryBackoff,
+				}).Info("retrying command")
 
-		stdout, err := cmd.StdoutPipe()
-		if err != nil {
-			logger.WithError(err).Error("failed to acquire stdout pipe on command")
-
-			return err
-		}
-		stderr, err := cmd.StderrPipe()
-		if err != nil {
-			logger.WithError(err).Error("failed to acquire stderr pipe on command")
-
-			return err
-		}
-
-		//nolint:errcheck
-		go io.Copy(os.Stdout, stdout)
-		//nolint:errcheck
-		go io.Copy(os.Stdout, stderr)
-
-		if err := cmd.Start(); err != nil {
-			logger.WithError(err).Error("failed to execute the command")
-
-			return err
-		}
-
-		// @step: wait for the command to finish
-		if err := cmd.Wait(); err != nil {
-			logger.WithError(err).Error("failed to execute command successfully")
-
-			if step.ErrorFile != "" {
-				if err := utils.TouchFile(step.ErrorFile); err != nil {
-					logger.WithError(err).WithField("file", step.ErrorFile).Error("failed to create error file")
-
-					return err
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(step.RetryBackoff):
 				}
 			}
 
-			return err
+			//nolint:gosec
+			cmd := exec.CommandContext(ctx, step.Shell, "-c", command)
+			cmd.Env = os.Environ()
+
+			logger := log.WithFields(log.Fields{
+				"command": i,
+				"attempt": attempt,
+			})
+
+			stdout, err := cmd.StdoutPipe()
+			if err != nil {
+				logger.WithError(err).Error("failed to acquire stdout pipe on command")
+				return err
+			}
+			stderr, err := cmd.StderrPipe()
+			if err != nil {
+				logger.WithError(err).Error("failed to acquire stderr pipe on command")
+				return err
+			}
+
+			//nolint:errcheck
+			go io.Copy(os.Stdout, stdout)
+			//nolint:errcheck
+			go io.Copy(os.Stdout, stderr)
+
+			if err := cmd.Start(); err != nil {
+				logger.WithError(err).Error("failed to execute the command")
+				lastErr = err
+				attempt++
+				continue
+			}
+
+			// @step: wait for the command to finish
+			if err := cmd.Wait(); err != nil {
+				logger.WithError(err).Error("command execution failed")
+				lastErr = err
+				attempt++
+				continue
+			}
+
+			// Command succeeded, break the retry loop
+			lastErr = nil
+			break
+		}
+
+		// If we exhausted all retries and still have an error
+		if lastErr != nil {
+			if step.ErrorFile != "" {
+				if err := utils.TouchFile(step.ErrorFile); err != nil {
+					log.WithError(err).WithField("file", step.ErrorFile).Error("failed to create error file")
+					return err
+				}
+			}
+			return fmt.Errorf("command failed after %d attempts: %w", attempt, lastErr)
 		}
 	}
 	log.Info("successfully executed the step")

--- a/cmd/step/types.go
+++ b/cmd/step/types.go
@@ -28,6 +28,10 @@ import (
 type Step struct {
 	// Commands is the commands and arguments to run
 	Commands []string
+	// RetryBackoff is the backoff time to retry ANY of the commands
+	RetryBackoff time.Duration
+	// RetryAttempts is the number of times to retry the commands before giving up
+	RetryAttempts int
 	// Comment adds a banner to the stage
 	Comment string
 	// ErrorFile is the path to a file which is created when the command failed
@@ -56,6 +60,12 @@ func (s Step) IsValid() error {
 
 	case s.Timeout < 0:
 		return errors.New("timeout must be greater than 0")
+
+	case s.RetryAttempts < 0:
+		return errors.New("retry attempts must be greater than or equal to 0")
+
+	case s.RetryBackoff < 0:
+		return errors.New("retry backoff must be greater than or equal to 0")
 
 	case len(s.UploadFile) > 0 && s.Namespace == "":
 		return errors.New("namespace must be specified when uploading files")

--- a/cmd/step/types.go
+++ b/cmd/step/types.go
@@ -28,8 +28,10 @@ import (
 type Step struct {
 	// Commands is the commands and arguments to run
 	Commands []string
-	// RetryBackoff is the backoff time to retry ANY of the commands
-	RetryBackoff time.Duration
+	// RetryMinBackoff is the minimum backoff time to retry ANY of the commands
+	RetryMinBackoff time.Duration
+	// RetryMaxJitter is the maximum random jitter to add to the backoff time
+	RetryMaxJitter time.Duration
 	// RetryAttempts is the number of times to retry the commands before giving up
 	RetryAttempts int
 	// Comment adds a banner to the stage
@@ -64,8 +66,11 @@ func (s Step) IsValid() error {
 	case s.RetryAttempts < 0:
 		return errors.New("retry attempts must be greater than or equal to 0")
 
-	case s.RetryBackoff < 0:
-		return errors.New("retry backoff must be greater than or equal to 0")
+	case s.RetryAttempts > 0 && s.RetryMinBackoff < 0:
+		return errors.New("minimum retry backoff must be greater than or equal to 0")
+
+	case s.RetryAttempts > 0 && s.RetryMaxJitter < 0:
+		return errors.New("maximum jitter must be greater than or equal to 0")
 
 	case len(s.UploadFile) > 0 && s.Namespace == "":
 		return errors.New("namespace must be specified when uploading files")


### PR DESCRIPTION
This adds flags to allow for commands to be retried with backoff (at this time all commands) but simple.

Regression test
```
13:44 $ docker run -it --entrypoint /bin/step europe-west2-docker.pkg.dev/appvia-hub/terranetes-executor-step-up/wf-step:1.0.4 --comment=gogo --command=true

=======================================================
GOGO
=======================================================
INFO[0000] successfully executed the step
✔ ~/projects/appvia/terranetes-controller [add-retry-to-step|✚ 2]
13:44 $ docker run -it --entrypoint /bin/step europe-west2-docker.pkg.dev/appvia-hub/terranetes-executor-step-up/wf-step:1.0.4 --comment=gogo --command=false

=======================================================
GOGO
=======================================================
ERRO[0000] command execution failed                      attempt=0 command=0 error="exit status 1"
Error: command failed after 1 attempts: exit status 1
[Error] command failed after 1 attempts: exit status 1
✘-1 ~/projects/appvia/terranetes-controller [add-retry-to-step|✚ 2]
```

New functionality
```
13:44 $ docker run -it --entrypoint /bin/step europe-west2-docker.pkg.dev/appvia-hub/terranetes-executor-step-up/wf-step:1.0.4 --comment=gogo --command=false --retry-attempts=3 --retry-min-backoff=3s --retry-max-jitter=5s

=======================================================
GOGO
=======================================================
ERRO[0000] command execution failed                      attempt=0 command=0 error="exit status 1"
INFO[0000] retrying command                              attempt=1 backoff=7.94378454s command=0
ERRO[0007] command execution failed                      attempt=1 command=0 error="exit status 1"
INFO[0007] retrying command                              attempt=2 backoff=3.351980995s command=0
ERRO[0011] command execution failed                      attempt=2 command=0 error="exit status 1"
INFO[0011] retrying command                              attempt=3 backoff=6.35325038s command=0
ERRO[0017] command execution failed                      attempt=3 command=0 error="exit status 1"
Error: command failed after 4 attempts: exit status 1
[Error] command failed after 4 attempts: exit status 1
```