### PR TITLE
[FIX] - Terrenetes Download

### DIFF
--- a/pkg/utils/download.go
+++ b/pkg/utils/download.go
@@ -36,25 +36,28 @@ func Download(ctx context.Context, source, destination string) error {
 		return err
 	}
 
-	if strings.HasPrefix(source, "http") {
-		source = strings.TrimPrefix(source, "http://")
-		source = strings.TrimPrefix(source, "https://")
+	// @step: just to keep the same behaviour as the previous version
+	if strings.HasPrefix(source, "https://github.com") {
+		source = strings.Replace(source, "https://github.com", "git::https://github.com", 2)
 	}
 
 	client := &getter.Client{
 		Ctx: ctx,
 		Dst: destination,
-		Detectors: []getter.Detector{
-			new(getter.GitHubDetector),
-			new(getter.GitLabDetector),
-			new(getter.GitDetector),
-			new(getter.BitBucketDetector),
-			new(getter.GCSDetector),
-			new(getter.S3Detector),
-			new(getter.FileDetector),
+		Options: []getter.ClientOption{
+			getter.WithMode(getter.ClientModeAny),
+			getter.WithDecompressors(getter.LimitedDecompressors(0, 0)),
+			getter.WithContext(ctx),
+			getter.WithDetectors([]getter.Detector{
+				new(getter.GitHubDetector),
+				new(getter.GitLabDetector),
+				new(getter.GitDetector),
+				new(getter.BitBucketDetector),
+				new(getter.GCSDetector),
+				new(getter.S3Detector),
+				new(getter.FileDetector),
+			}),
 		},
-		Mode:    getter.ClientModeAny,
-		Options: []getter.ClientOption{},
 		Pwd:     pwd,
 		Src:     source,
 	}


### PR DESCRIPTION
Attempting to fix up the issue related to artifactory download in the tnctl create revision command,

We had a bug in the code which was cause issues with direct http calls.

```go
-       if strings.HasPrefix(source, "http") {
-               source = strings.TrimPrefix(source, "http://")
-               source = strings.TrimPrefix(source, "https://")
```

This has been removed.

The main issue however was found when dealing with Artifactory assets, using the follow example.

```shell
bin/tnctl create revision https://USERNAME:TOKEN@trial4x3ad1.jfrog.io/artifactory/art-terraform-modules-local/kash/rds/aws/1.0.0 -f test.yaml
```

We are getting a 404. Adding a `.zip` to the URL i.e. `/kash/rds/aws/1.0.0.zip` allowed us to download the zip file. I’m guessing we are missing a headers information which artifactory requires. 

The second issue comes from the fact that zip is downloaded, BUT extracted into a subfolder in the destination directory - i’ve confirmed the same bahavior when using go-getter binary directory

```shell
ls /tmp/test-download
 .   ..   terraform-aws-rds
```

In the URL for the revision we fix this by adding the submodule path i.e. 

```shell
bin/tnctl create revision https://USERNAME:TOKEN@trial4x3ad1.jfrog.io/artifactory/art-terraform-modules-local/kash/rds/aws/1.0.0.zip//terraform-aws-rds -f test.yaml
```

I’m guessing terraform most be doing something outside of the go-getter li to fix this.