### PR TITLE
error in applying checkov resource selector

### DIFF
--- a/pkg/utils/policies/find.go
+++ b/pkg/utils/policies/find.go
@@ -100,7 +100,7 @@ func FindMatchingPolicy(
 
 			// @step: if we have a resource selector lets check it
 			if list.Items[i].Spec.Constraints.Checkov.Selector.Resource != nil {
-				selector, err := metav1.LabelSelectorAsSelector(list.Items[i].Spec.Constraints.Checkov.Selector.Namespace)
+				selector, err := metav1.LabelSelectorAsSelector(list.Items[i].Spec.Constraints.Checkov.Selector.Resource)
 				if err != nil {
 					return nil, err
 				}


### PR DESCRIPTION
When applying a Policy with 

`spec.constraints.checkov.selector.resource.matchExpressions`  
or 
`spec.constraints.checkov.selector.resource.matchLabels`

the filters are totally ignored, while with namespace selector the filters properly work.