### PR TITLE
[HELM] fix the registerCRDs parameter

### DIFF
--- a/charts/terranetes-controller/templates/deployment.yaml
+++ b/charts/terranetes-controller/templates/deployment.yaml
@@ -96,6 +96,7 @@ spec:
             - --tls-key={{ .Values.controller.webhooks.tlsKey }}
             - --webhooks-port={{ .Values.controller.webhooks.port }}
             {{- end }}
+            - --register-crds={{ .Values.controller.registerCRDs }}
             {{- range $key, $value := .Values.controller.extraArgs }}
             - --{{ $key }}={{ $value }}
             {{- end }}

--- a/charts/terranetes-controller/templates/rbac.yaml
+++ b/charts/terranetes-controller/templates/rbac.yaml
@@ -21,15 +21,15 @@ kind: ClusterRole
 metadata:
   name: {{ include "terranetes-controller.fullname" . }}
 rules:
-  {{- if .Values.controller.registerCRDs }}
   - apiGroups:
       - apiextensions.k8s.io
     resources:
       - customresourcedefinitions
     verbs:
-      - create
       - get
       - list
+  {{- if .Values.controller.registerCRDs }}
+      - create
       - patch
       - update
   {{- end }}


### PR DESCRIPTION
When setting the parameter to false, the CRDs are still being registered and controller fails to start as it is not able to read the CRDs.