### PR TITLE
[BUILD] - Helm Job Image Version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,7 +86,7 @@ jobs:
           make shfmt
 
   helm:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Changed the run-on from ubuntu-20.04 (deprecated) to latest
