### PR TITLE
Potential fix for code scanning alert no. 21: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,7 +1,9 @@
 ---
 name: E2E
 run-name: Running E2E for ${{ inputs.cloud }} (${{ github.ref_name }})
-
+permissions:
+  contents: read
+  packages: write
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/appvia/terranetes-controller/security/code-scanning/21](https://github.com/appvia/terranetes-controller/security/code-scanning/21)

To fix the issue, add a `permissions` block at the root level of the workflow. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions` blocks. Based on the workflow's actions, the minimal required permissions are likely `contents: read` (to access repository contents) and possibly `packages: write` (to upload artifacts). The `permissions` block should be added near the top of the file, just after the `name` and `run-name` fields.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
