### PR TITLE
Potential fix for code scanning alert no. 20: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/versions.yaml
+++ b/.github/workflows/versions.yaml
@@ -1,5 +1,8 @@
 ---
 name: Image Versions
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/appvia/terranetes-controller/security/code-scanning/20](https://github.com/appvia/terranetes-controller/security/code-scanning/20)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the required permissions. Based on the workflow's actions, the following permissions are needed:
- `contents: read` for accessing repository contents.
- `pull-requests: write` for creating pull requests.

This ensures that the workflow has only the necessary permissions to perform its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
