### PR TITLE
fix: ConfigurationThreshold ignored

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,7 +1,9 @@
 ---
 name: E2E
 run-name: Running E2E for ${{ inputs.cloud }} (${{ github.ref_name }})
-
+permissions:
+  contents: read
+  packages: write
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/versions.yaml
+++ b/.github/workflows/versions.yaml
@@ -1,5 +1,8 @@
 ---
 name: Image Versions
+permissions:
+  contents: read
+  pull-requests: write
 
 on:
   schedule:

--- a/charts/terranetes-controller/Chart.yaml
+++ b/charts/terranetes-controller/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: terranetes-controller
 description: Controller used to provision a terraform workflow within kubernetes
 type: application
-version: v0.8.4
-appVersion: v0.5.5
+version: v0.8.5
+appVersion: v0.5.6
 sources:
   - https://github.com/appvia/terranetes-controller
   - https://github.com/appvia/terranetes

--- a/charts/terranetes-controller/values.yaml
+++ b/charts/terranetes-controller/values.yaml
@@ -43,11 +43,11 @@ controller:
     # policy is image for policy
     policy: bridgecrew/checkov:3.2.298
     # preload is the image to use for preload data jobs
-    preload: ghcr.io/appvia/terranetes-executor:v0.5.5
+    preload: ghcr.io/appvia/terranetes-executor:v0.5.6
     # is the controller image
-    controller: ghcr.io/appvia/terranetes-controller:v0.5.5
+    controller: ghcr.io/appvia/terranetes-controller:v0.5.6
     # The terranetes image used when running jobs
-    executor: ghcr.io/appvia/terranetes-executor:v0.5.5
+    executor: ghcr.io/appvia/terranetes-executor:v0.5.6
   # Rate limting on configurations to prevent the controller from being overwhelmed. This
   # is the percentage of configurations which are permitted to run a plan at any one time.
   # Note, zero means no rate limiting is applied.

--- a/pkg/apis/terraform/v1alpha1/configuration_types.go
+++ b/pkg/apis/terraform/v1alpha1/configuration_types.go
@@ -504,7 +504,7 @@ func (c *Configuration) IsRevisioned() bool {
 		return false
 	}
 
-	return false
+	return true
 }
 
 // GetNamespacedName returns the namespaced resource type

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -174,6 +174,7 @@ func New(cfg *rest.Config, config Config) (*Server, error) {
 		BackendTemplate:              config.BackendTemplate,
 		BackoffLimit:                 config.BackoffLimit,
 		BinaryPath:                   config.BinaryPath,
+		ConfigurationThreshold:       config.ConfigurationThreshold,
 		ControllerJobLabels:          jobLabels,
 		ControllerNamespace:          config.Namespace,
 		DefaultExecutorCPULimit:      config.ExecutorCPULimit,


### PR DESCRIPTION
The `ConfigurationThreshold` parameter is ignored because it is not passed into `configuration.Controller`.

The logs now indicate that it is working after the change:
```
{"level":"debug","msg":"checking configuration is within the threshold","running":5,"running_percent":16.666666666666664,"threshold":0.1,"time":"2026-01-02T15:46:58+01:00","total":30}
{"kind":"configuration","level":"warning","msg":"Configuration is over the threshold for running configurations, waiting in queue","name":"bucket3","namespace":"default","time":"2026-01-02T15:46:58+01:00"}
```