### PR TITLE
chore: build images with multi-platform (amd64 and arm64)

### DIFF
--- a/.github/workflows/images.yaml
+++ b/.github/workflows/images.yaml
@@ -50,6 +50,10 @@ jobs:
             latest=auto
           tags: |
             type=raw,value=${{ steps.get_image_tag.outputs.image_tag }}
+      - name: Setup docker buildx
+        uses: docker/setup-buildx-action@v4.3.0
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4.3.0
       - name: Build & Push
         uses: docker/build-push-action@v6.18.0
         with:
@@ -59,3 +63,4 @@ jobs:
           labels: ${{ steps.docker_meta.outputs.labels }}
           push: true
           tags: ${{ steps.docker_meta.outputs.tags }}
+          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
This adds multi-platform building to `images` GitHub Action workflow to support running Terranetes on ARM64 architecture.

Closes https://github.com/appvia/terranetes-controller/issues/1795